### PR TITLE
fix(upload-client): crash when building search query with falsy values

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Run integration tests
         run: npm run test:production
         env:
-          UC_KEY_FOR_INTEGRATION_TESTS: ${{ secrets.UC_KEY_FOR_INTEGRATION_TESTS }}
+          UC_KEY_FOR_INTEGRATION_TESTS: ${{ secrets.UPLOAD_CLIENT_DEFAULT_PUBLIC_KEY }}
 

--- a/packages/upload-client/src/tools/getUrl.ts
+++ b/packages/upload-client/src/tools/getUrl.ts
@@ -1,42 +1,36 @@
-type BaseTypes = string | number | void
+type Query = Record<string, unknown>
 
-type Query = {
-  [key: string]: BaseTypes | BaseTypes[] | { [key: string]: BaseTypes }
+const buildSearchParams = (query: Query): string => {
+  const searchParams = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value)
+        .filter((entry) => entry[1] ?? false)
+        .forEach((entry) =>
+          searchParams.set(`${key}[${entry[0]}]`, String(entry[1]))
+        )
+    } else if (Array.isArray(value)) {
+      value.forEach((val) => {
+        searchParams.append(`${key}[]`, val)
+      })
+    } else if (typeof value === 'string' && value) {
+      searchParams.set(key, value)
+    } else if (typeof value === 'number') {
+      searchParams.set(key, value.toString())
+    }
+  }
+
+  return searchParams.toString()
 }
 
-const serializePair = (key: string, value: BaseTypes): string | null =>
-  typeof value !== 'undefined' ? `${key}=${encodeURIComponent(value)}` : null
-
-// TODO: generalize value transforming logic and use it here and inside `buildFormData`
-const createQuery = (query: Query): string =>
-  Object.entries(query)
-    .reduce<(string | null)[]>((params, [key, value]) => {
-      let param
-      if (typeof value === 'object' && !Array.isArray(value)) {
-        param = Object.entries(value)
-          .filter((entry) => typeof entry[1] !== 'undefined')
-          .map((entry) =>
-            serializePair(`${key}[${entry[0]}]`, String(entry[1]))
-          )
-      } else if (Array.isArray(value)) {
-        param = value.map((val) => serializePair(`${key}[]`, val))
-      } else {
-        param = serializePair(key, value)
-      }
-
-      return params.concat(param)
-    }, [])
-    .filter((x) => !!x)
-    .join('&')
-
-const getUrl = (base: string, path: string, query?: Query): string =>
-  [
-    base,
-    path,
-    query && Object.keys(query).length > 0 ? '?' : '',
-    query && createQuery(query)
-  ]
-    .filter(Boolean)
-    .join('')
+const getUrl = (base: string, path: string, query?: Query): string => {
+  const url = new URL(base)
+  url.pathname = path
+  if (query) {
+    url.search = buildSearchParams(query)
+  }
+  return url.toString()
+}
 
 export default getUrl

--- a/packages/upload-client/test/tools/getUrl.test.ts
+++ b/packages/upload-client/test/tools/getUrl.test.ts
@@ -2,37 +2,37 @@ import getUrl from '../../src/tools/getUrl'
 
 describe('create URL', () => {
   it('should create url', () => {
-    expect(getUrl('https:/github.com', '/base/')).toBe(
-      'https:/github.com/base/'
+    expect(getUrl('https://github.com', '/base/')).toBe(
+      'https://github.com/base/'
     )
   })
 
   it('should work with query', () => {
     expect(
-      getUrl('https:/github.com', '/base/', { lol: 'param', kek: 'param' })
-    ).toBe('https:/github.com/base/?lol=param&kek=param')
+      getUrl('https://github.com', '/base/', { lol: 'param', kek: 'param' })
+    ).toBe('https://github.com/base/?lol=param&kek=param')
   })
 
-  it('query should accept arrays', () => {
+  it('should accept arrays', () => {
     expect(
-      getUrl('https:/github.com', '/base/', {
+      getUrl('https://github.com', '/base/', {
         lol: 'param',
         kek: ['param1', 'param2']
       })
-    ).toBe('https:/github.com/base/?lol=param&kek[]=param1&kek[]=param2')
+    ).toBe('https://github.com/base/?lol=param&kek[]=param1&kek[]=param2')
   })
 
-  it('query should escape url', () => {
+  it('should escape url', () => {
     expect(
-      getUrl('https:/github.com', '/base/', {
-        lol: 'https:/github.com'
+      getUrl('https://github.com', '/base/', {
+        lol: 'https://github.com'
       })
-    ).toBe('https:/github.com/base/?lol=https%3A%2Fgithub.com')
+    ).toBe('https://github.com/base/?lol=https%3A%2F%2Fgithub.com')
   })
 
-  it('query should accept objects', () => {
+  it('should accept objects', () => {
     expect(
-      getUrl('https:/github.com', '/base/', {
+      getUrl('https://github.com', '/base/', {
         lol: 'param',
         kek: {
           key1: 'value1',
@@ -42,7 +42,7 @@ describe('create URL', () => {
         }
       })
     ).toBe(
-      'https:/github.com/base/?lol=param&kek[key1]=value1&kek[key2]=2&kek[key4]=null'
+      'https://github.com/base/?lol=param&kek[key1]=value1&kek[key2]=2&kek[key4]=null'
     )
   })
 })

--- a/packages/upload-client/test/tools/getUrl.test.ts
+++ b/packages/upload-client/test/tools/getUrl.test.ts
@@ -19,7 +19,9 @@ describe('create URL', () => {
         lol: 'param',
         kek: ['param1', 'param2']
       })
-    ).toBe('https://github.com/base/?lol=param&kek[]=param1&kek[]=param2')
+    ).toBe(
+      'https://github.com/base/?lol=param&kek%5B%5D=param1&kek%5B%5D=param2'
+    )
   })
 
   it('should escape url', () => {
@@ -33,16 +35,29 @@ describe('create URL', () => {
   it('should accept objects', () => {
     expect(
       getUrl('https://github.com', '/base/', {
-        lol: 'param',
-        kek: {
-          key1: 'value1',
-          key2: 2,
-          key3: undefined,
-          key4: null as never
+        key0: 'value0',
+        key1: {
+          deepKey0: 'deepValue0',
+          deepKey1: 1,
+          deepKey2: undefined,
+          deepKey3: null,
+          deepKey4: ''
         }
       })
     ).toBe(
-      'https://github.com/base/?lol=param&kek[key1]=value1&kek[key2]=2&kek[key4]=null'
+      'https://github.com/base/?key0=value0&key1%5BdeepKey0%5D=deepValue0&key1%5BdeepKey1%5D=1'
     )
+  })
+
+  it('should ignore falsy values', () => {
+    expect(
+      getUrl('https://github.com', '/base/', {
+        key0: 'value0',
+        key1: null,
+        key2: undefined,
+        key3: 0,
+        key4: ''
+      })
+    ).toBe('https://github.com/base/?key0=value0&key3=0')
   })
 })

--- a/packages/upload-client/test/uploadFile/uploadDirect.test.ts
+++ b/packages/upload-client/test/uploadFile/uploadDirect.test.ts
@@ -4,6 +4,7 @@ import { UploadClientError } from '../../src/tools/errors'
 import uploadDirect from '../../src/uploadFile/uploadDirect'
 import { jest, expect } from '@jest/globals'
 
+// TODO: add tests for metadata
 describe('uploadDirect', () => {
   it('should resolves when file is ready on CDN', async () => {
     const fileToUpload = factory.image('blackSquare').data

--- a/packages/upload-client/test/uploadFile/uploadFromUrl.test.ts
+++ b/packages/upload-client/test/uploadFile/uploadFromUrl.test.ts
@@ -12,6 +12,7 @@ import { jest, expect } from '@jest/globals'
 
 jest.setTimeout(60000)
 
+// TODO: add tests for metadata
 describe('uploadFromUrl', () => {
   it('should resolves when file is ready on CDN', async () => {
     const sourceUrl = factory.imageUrl('valid')

--- a/packages/upload-client/test/uploadFile/uploadMultipart.test.ts
+++ b/packages/upload-client/test/uploadFile/uploadMultipart.test.ts
@@ -6,6 +6,7 @@ import { jest, expect } from '@jest/globals'
 
 jest.setTimeout(60000)
 
+// TODO: add tests for metadata
 describe('uploadMultipart', () => {
   const fileToUpload = factory.file(12).data
   const settings = getSettingsForTesting({

--- a/ship.config.js
+++ b/ship.config.js
@@ -5,7 +5,7 @@ export default {
   monorepo: {
     mainVersionFile: 'package.json',
     packagesToBump: ['packages/*'],
-    packagesToPublish: ['packages/*']
+    packagesToPublish: ['packages/upload-client']
   },
   publishCommand: ({ defaultCommand }) => `${defaultCommand} --access public`,
   versionUpdated: ({ version, dir }) => {


### PR DESCRIPTION
This bug is noticed in the current version of uc-blocks.
We pass falsy values to upload-client inside options and it crashes. The reason is wrong checking for the key-value object.
I rewrited this code using URLSearchParams, which is became native in Node 16 and added test cases for it.