### PR TITLE
chore: skip tests when building the library

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ export default {
     }
   },
   setupFiles: ['../../env.js'],
-  reporters: ['default', 'github-actions']
+  reporters: ['default', 'github-actions'],
+  setupFilesAfterEnv: ['jest-extended/all']
 }

--- a/packages/api-client-utils/tsconfig.build.json
+++ b/packages/api-client-utils/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/packages/rest-client/jest.config.js
+++ b/packages/rest-client/jest.config.js
@@ -2,6 +2,5 @@ import baseConfig from '../../jest.config.js'
 
 export default {
   ...baseConfig,
-  globalSetup: './test/globalSetup.js',
-  setupFilesAfterEnv: ['jest-extended/all']
+  globalSetup: './test/globalSetup.js'
 }

--- a/packages/rest-client/src/api/addons/addonExecutionStatus.test.ts
+++ b/packages/rest-client/src/api/addons/addonExecutionStatus.test.ts
@@ -1,22 +1,18 @@
 import { describe, it } from '@jest/globals'
 import { addonExecutionStatus } from './addonExecutionStatus'
 
+import { ADDONS_UUID } from '../../../test/fixtures'
 import { testSettings } from '../../../test/helpers'
 import { AddonName } from '../../types/AddonName'
 import { executeAddon } from './executeAddon'
-import { ADDONS_UUID } from '../../../test/fixtures'
-import { copyFileToLocalStorage } from '../file/copyFileToLocalStorage'
+import { AddonExecutionStatus } from '../../types/AddonExecutionStatus'
 
 describe('addonExecutionStatus', () => {
   it('should work', async () => {
-    const copy = await copyFileToLocalStorage(
-      { source: ADDONS_UUID, store: false },
-      testSettings
-    )
     const { requestId } = await executeAddon(
       {
         addonName: AddonName.AWS_REKOGNITION_DETECT_LABELS,
-        target: copy.result.uuid
+        target: ADDONS_UUID
       },
       testSettings
     )
@@ -27,7 +23,12 @@ describe('addonExecutionStatus', () => {
       },
       testSettings
     )
-    expect(response.status).toBeTruthy()
+    expect(response.status).toBeOneOf([
+      AddonExecutionStatus.DONE,
+      AddonExecutionStatus.ERROR,
+      AddonExecutionStatus.IN_PROGRESS,
+      AddonExecutionStatus.UNKNOWN
+    ])
   })
 
   it('should throw error if non-200 status received', async () => {

--- a/packages/rest-client/src/api/conversion/documentConversionJobStatus.test.ts
+++ b/packages/rest-client/src/api/conversion/documentConversionJobStatus.test.ts
@@ -5,19 +5,12 @@ import { DOCUMENT_UUID } from '../../../test/fixtures'
 import { testSettings } from '../../../test/helpers'
 import { ConversionStatus } from '../../types/ConversionStatus'
 import { convertDocument } from './convertDocument'
-import { copyFileToLocalStorage } from '../file/copyFileToLocalStorage'
-import { delay } from '@uploadcare/api-client-utils'
 
 describe('documentConversionJobStatus', () => {
   it('should work', async () => {
-    const copy = await copyFileToLocalStorage(
-      { source: DOCUMENT_UUID, store: false },
-      testSettings
-    )
-
     const { result } = await convertDocument(
       {
-        paths: [`${copy.result.uuid}/document/-/format/docx/`],
+        paths: [`${DOCUMENT_UUID}/document/-/format/docx/`],
         store: 'false'
       },
       testSettings

--- a/packages/rest-client/src/api/conversion/videoConversionJobStatus.test.ts
+++ b/packages/rest-client/src/api/conversion/videoConversionJobStatus.test.ts
@@ -4,19 +4,13 @@ import { videoConversionJobStatus } from './videoConversionJobStatus'
 import { VIDEO_UUID } from '../../../test/fixtures'
 import { testSettings } from '../../../test/helpers'
 import { ConversionStatus } from '../../types/ConversionStatus'
-import { copyFileToLocalStorage } from '../file/copyFileToLocalStorage'
 import { convertVideo } from './convertVideo'
 
 describe('videoConversionJobStatus', () => {
   it('should work', async () => {
-    const copy = await copyFileToLocalStorage(
-      { source: VIDEO_UUID, store: false },
-      testSettings
-    )
-
     const { result } = await convertVideo(
       {
-        paths: [`${copy.result.uuid}/video/-/format/mp4/`],
+        paths: [`${VIDEO_UUID}/video/-/format/mp4/`],
         store: 'false'
       },
       testSettings

--- a/packages/rest-client/tsconfig.build.json
+++ b/packages/rest-client/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"],
 }

--- a/packages/upload-client/test/uploadFile/uploadFile.test.ts
+++ b/packages/upload-client/test/uploadFile/uploadFile.test.ts
@@ -1,6 +1,9 @@
+import { expect, jest } from '@jest/globals'
 import { uploadFile } from '../../src/uploadFile'
 import * as factory from '../_fixtureFactory'
 import { getSettingsForTesting } from '../_helpers'
+
+jest.setTimeout(60000)
 
 /**
  * Those spying tests are commented because jest isn't able to mock statically imported ESM modules

--- a/packages/upload-client/tsconfig.build.json
+++ b/packages/upload-client/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["node_modules", "test", "mock-server"]
+  "exclude": ["node_modules", "**/*.test.ts", "test", "mock-server"]
 }


### PR DESCRIPTION
* Do not handle test files while building bundle with typescript
* Fix races when testing conversion/addons api. Copying files has unstable timings and the copied file could be not-ready instantly so it leads to errors while testing.