### PR TITLE
feat(rest-client): searchFiles for POST /files/search/

### DIFF
--- a/packages/api-client-utils/src/camelizeKeys.test.ts
+++ b/packages/api-client-utils/src/camelizeKeys.test.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 import {
+  Camelize,
   camelizeKeys,
   camelizeString,
   SnakeCasedPropertiesDeep
@@ -79,6 +80,42 @@ describe('camelizeKeys types', () => {
     expectTypeOf(camelizeKeys<Source>)
       .parameter(1)
       .toEqualTypeOf<{ ignoreKeys: string[] } | undefined>()
+  })
+})
+
+describe('camelizeString types', () => {
+  it('should report the camelCase literal, so constants can be derived', () => {
+    expectTypeOf(
+      camelizeString('non_field_errors')
+    ).toEqualTypeOf<'nonFieldErrors'>()
+    expectTypeOf<
+      Camelize<'non_field_errors'>
+    >().toEqualTypeOf<'nonFieldErrors'>()
+  })
+
+  it('should cover every separator the runtime splits on in API keys', () => {
+    expectTypeOf<Camelize<'foo-bar'>>().toEqualTypeOf<'fooBar'>()
+    expectTypeOf<Camelize<'foo.bar'>>().toEqualTypeOf<'fooBar'>()
+    expectTypeOf<Camelize<'foo bar'>>().toEqualTypeOf<'fooBar'>()
+    expectTypeOf<Camelize<'a__b'>>().toEqualTypeOf<'aB'>()
+  })
+
+  it('should lower only the first character of the first segment', () => {
+    expectTypeOf<Camelize<'Foo_bar'>>().toEqualTypeOf<'fooBar'>()
+    expectTypeOf<
+      Camelize<'detected_MIME_type'>
+    >().toEqualTypeOf<'detectedMIMEType'>()
+  })
+
+  it('should leave a separator-free string alone', () => {
+    expectTypeOf<Camelize<'size'>>().toEqualTypeOf<'size'>()
+    expectTypeOf<Camelize<'alreadyCamel'>>().toEqualTypeOf<'alreadyCamel'>()
+  })
+
+  it('should stay a string for a non-literal input', () => {
+    // Not `toEqualTypeOf<string>`: with a non-literal argument the conditional
+    // never reduces, and expect-type cannot equate a deferred type.
+    expectTypeOf(camelizeString('' as string)).toBeString()
   })
 })
 

--- a/packages/api-client-utils/src/camelizeKeys.ts
+++ b/packages/api-client-utils/src/camelizeKeys.ts
@@ -2,7 +2,36 @@ import { isObject } from './isObject'
 
 const SEPARATOR = /\W|_/g
 
-export function camelizeString<T extends string>(text: T): T {
+/**
+ * Joins the segments of a separated string, capitalising every one after the
+ * first — the type-level half of {@link camelizeString}.
+ *
+ * Covers the separators that appear in API keys (`_`, `-`, `.`, space). Any
+ * other non-word character is a separator at runtime but not here, so a string
+ * containing one keeps its own literal type rather than gaining a wrong one.
+ */
+type JoinSegments<S extends string> = S extends `${infer Head}_${infer Tail}`
+  ? `${Head}${Capitalize<JoinSegments<Tail>>}`
+  : S extends `${infer Head}-${infer Tail}`
+    ? `${Head}${Capitalize<JoinSegments<Tail>>}`
+    : S extends `${infer Head}.${infer Tail}`
+      ? `${Head}${Capitalize<JoinSegments<Tail>>}`
+      : S extends `${infer Head} ${infer Tail}`
+        ? `${Head}${Capitalize<JoinSegments<Tail>>}`
+        : S
+
+/** What {@link camelizeString} turns `S` into. */
+export type Camelize<S extends string> = Uncapitalize<JoinSegments<S>>
+
+/**
+ * Rewrite a separated string as camelCase: `non_field_errors` becomes
+ * `nonFieldErrors`.
+ *
+ * The return type follows the value, so a literal in gives the camelCase
+ * literal out and constants can be derived from the spelling they came from
+ * instead of being written twice.
+ */
+export function camelizeString<S extends string>(text: S): Camelize<S> {
   return text
     .split(SEPARATOR)
     .map(
@@ -10,7 +39,7 @@ export function camelizeString<T extends string>(text: T): T {
         word.charAt(0)[index > 0 ? 'toUpperCase' : 'toLowerCase']() +
         word.slice(1)
     )
-    .join('') as T
+    .join('') as Camelize<S>
 }
 
 type SnakeCase<S extends string> = S extends `${infer Head}${infer Tail}`

--- a/packages/api-client-utils/src/index.ts
+++ b/packages/api-client-utils/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  Camelize,
   camelizeKeys,
   camelizeString,
   SnakeCasedPropertiesDeep

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -168,13 +168,78 @@ const result = await updateTags(
 
 See [docs][uc-file-tags] for normalization rules and limits.
 
+#### File search
+
+`searchFiles` queries the project's files. Every condition is optional, but at
+least one is required, and conditions combine with AND:
+
+```typescript
+import { searchFiles, UploadcareSimpleAuthSchema } from '@uploadcare/rest-client';
+
+const authSchema = new UploadcareSimpleAuthSchema({
+  publicKey: 'YOUR_PUBLIC_KEY',
+  secretKey: 'YOUR_SECRET_KEY',
+});
+
+const page = await searchFiles(
+  {
+    tags: { all: ['cat', 'animal'], none: ['draft'] },
+    isImage: true,
+    sort: [{ field: 'datetime_uploaded', order: 'desc' }, { field: 'size' }],
+    limit: 50
+  },
+  { authSchema }
+);
+
+page.total; // 42
+page.results[0].uuid;
+```
+
+Full-text conditions are `query` (across searchable fields) and `phrase` (per
+field), both needing at least 4 characters, with `fuzziness: true` for typo
+tolerance. `exact` matches whole values, and its `metadata` keys are yours to
+name:
+
+```typescript
+const page = await searchFiles(
+  {
+    exact: {
+      detectedMimeType: ['image/png'],
+      metadata: { color: ['red', 'blue'] }
+    },
+    phrase: { originalFilename: 'invoice' },
+    datetimeUploaded: { gte: new Date('2026-01-01') },
+    size: { gt: 1_000_000 }
+  },
+  { authSchema }
+);
+
+// tokens that matched, wrapped in <em>
+page.results[0].highlight?.originalFilename;
+```
+
+Pass `include: 'appdata'` to embed add-on data. A malformed query rejects with a
+`RestClientError` whose `errors` field carries the server's complaints per field:
+
+```typescript
+try {
+  await searchFiles({ query: 'abc' }, { authSchema });
+} catch (error) {
+  error.errors; // { query: ['ensure this value has at least 4 characters'] }
+}
+```
+
+Newly uploaded files are indexed asynchronously, so a file may not be findable
+immediately after upload. See [docs][uc-file-search] for the full condition
+reference.
+
 ### Settings
 
 List of all available Settings is available at the [rest-client API Reference](https://uploadcare.github.io/uploadcare-js-api-clients/rest-client/modules#UserSettings).
 
 ### Pagination
 
-We have the only two paginatable API methods - `listOfFiles` and `listOfGroups`. You can use one of those methods below to paginate over.
+Three API methods paginate: `listOfFiles`, `listOfGroups` and `searchFiles`. You can use one of those methods below to paginate over. Note that search caps `offset + limit` at 1000, so a walk over search results ends there however large `total` is.
 
 #### Using async generator and `paginate()` helper
 
@@ -326,3 +391,4 @@ request at [hello@uploadcare.com][uc-email-hello].
 [build-url]: https://github.com/uploadcare/uploadcare-js-api-clients/actions/workflows/checks.yml
 [uc-docs-rest-api]: https://uploadcare.com/api-refs/rest-api/v0.7.0/?utm_source=github&utm_campaign=uploadcare-js-api-clients
 [uc-file-tags]: https://uploadcare.com/docs/file-tags/
+[uc-file-search]: https://uploadcare.com/docs/file-search/

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -204,7 +204,7 @@ name:
 const page = await searchFiles(
   {
     exact: {
-      detectedMimeType: ['image/png'],
+      detected_mime_type: ['image/png'],
       metadata: { color: ['red', 'blue'] }
     },
     phrase: { originalFilename: 'invoice' },
@@ -218,16 +218,27 @@ const page = await searchFiles(
 page.results[0].highlight?.originalFilename;
 ```
 
-Pass `include: 'appdata'` to embed add-on data. A malformed query rejects with a
-`RestClientError` whose `errors` field carries the server's complaints per field:
+Pass `include: 'appdata'` to embed add-on data. A malformed or empty query
+rejects with a `RestClientValidationError`, which carries the server's
+complaints keyed by field. It extends `RestClientError`, so existing handling
+keeps working:
 
 ```typescript
+import { isRestClientValidationError, searchFiles } from '@uploadcare/rest-client';
+
 try {
   await searchFiles({ query: 'abc' }, { authSchema });
 } catch (error) {
-  error.errors; // { query: ['ensure this value has at least 4 characters'] }
+  if (isRestClientValidationError(error)) {
+    error.errors; // { query: ['Must be at least 4 characters.'] }
+    error.message; // '[400 Bad Request] query: Must be at least 4 characters.'
+  }
 }
 ```
+
+Errors that span more than one field, and the empty-query case, arrive under
+`non_field_errors`. Complaints the API nests under a structured field are
+flattened to a dotted path, so a bad `size` reads as `size`.
 
 Newly uploaded files are indexed asynchronously, so a file may not be findable
 immediately after upload. See [docs][uc-file-search] for the full condition

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -202,7 +202,7 @@ const page = await searchFiles(
   {
     tags: { all: ['cat', 'animal'], none: ['draft'] },
     isImage: true,
-    sort: [{ field: 'datetime_uploaded', order: 'desc' }, { field: 'size' }],
+    sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
     limit: 50
   },
   { authSchema }
@@ -215,17 +215,17 @@ page.results[0].uuid
 Full-text conditions are `query` (across searchable fields) and `phrase` (per
 field), both needing at least 4 characters, with `fuzziness: true` for typo
 tolerance. `exact` matches whole values, and its `metadata` keys are yours to
-name. Field names inside `phrase`, `exact`, `sort` and `highlight` are the API's
-own, so one vocabulary covers filtering, sorting and highlighting:
+name. Everything you write is camelCase; only your own metadata keys and tag
+values keep the spelling you gave them:
 
 ```typescript
 const page = await searchFiles(
   {
     exact: {
-      detected_mime_type: ['image/png'],
+      detectedMimeType: ['image/png'],
       metadata: { color: ['red', 'blue'] }
     },
-    phrase: { original_filename: 'invoice' },
+    phrase: { originalFilename: 'invoice' },
     datetimeUploaded: { gte: new Date('2026-01-01') },
     size: { gt: 1_000_000 }
   },
@@ -233,7 +233,7 @@ const page = await searchFiles(
 )
 
 // tokens that matched, wrapped in <em>
-page.results[0].highlight?.original_filename
+page.results[0].highlight?.originalFilename
 ```
 
 Pass `include: 'appdata'` to embed add-on data. A malformed or empty query
@@ -258,8 +258,8 @@ try {
 ```
 
 Errors that span more than one field, and the empty-query case, arrive under
-`non_field_errors`. Complaints the API nests under a structured field are
-flattened to a dotted path, so a bad `size` reads as `size`.
+`nonFieldErrors`. Field names are camelized like any other response, except a
+key naming your own metadata, which keeps the spelling you gave it.
 
 Newly uploaded files are indexed asynchronously, so a file may not be findable
 immediately after upload. See [docs][uc-file-search] for the full condition

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -6,7 +6,7 @@
       alt="">
 </a>
 
-`@uploadcare/rest-client` is a JavaScript and TypeScript SDK for the Uploadcare [REST API][uc-docs-rest-api]. It covers file management (upload, delete, copy to local/remote storage, metadata, tags), groups, webhooks, media conversion (video and document), and add-ons (virus scanning, image recognition, background removal). Works in Node.js and browser. Supports Simple and signature-based authentication, async pagination with generators, automatic retry with exponential backoff for throttled requests, and job status polling for async operations.
+`@uploadcare/rest-client` is a JavaScript and TypeScript SDK for the Uploadcare [REST API][uc-docs-rest-api]. It covers file management (upload, delete, copy to local/remote storage, metadata, tags), full-text and faceted file search, groups, webhooks, media conversion (video and document), and add-ons (virus scanning, image recognition, background removal). Works in Node.js and browser. Supports Simple and signature-based authentication, async pagination with generators, automatic retry with exponential backoff for throttled requests, and job status polling for async operations.
 
 [API Reference](https://uploadcare.github.io/uploadcare-js-api-clients/rest-client/)
 
@@ -261,9 +261,27 @@ Errors that span more than one field, and the empty-query case, arrive under
 `nonFieldErrors`. Field names are camelized like any other response, except a
 key naming your own metadata, which keeps the spelling you gave it.
 
+Results paginate through `limit` and `offset`, so `searchFiles` works with the
+[pagination helpers](#pagination) below — bearing in mind the API requires
+`offset + limit` to stay under 1000:
+
+```typescript
+import { paginate, searchFiles } from '@uploadcare/rest-client'
+
+const pages = paginate(searchFiles)(
+  { tags: { any: ['cat'] }, limit: 100 },
+  { authSchema }
+)
+
+for await (const page of pages) {
+  console.log(page.results.length)
+}
+```
+
 Newly uploaded files are indexed asynchronously, so a file may not be findable
-immediately after upload. See [docs][uc-file-search] for the full condition
-reference.
+immediately after upload — expect a few seconds. See [docs][uc-file-search] for
+the full condition reference, and the [API Reference][api-reference] for every
+option and its type.
 
 ### Settings
 
@@ -431,3 +449,4 @@ request at [hello@uploadcare.com][uc-email-hello].
 [uc-docs-rest-api]: https://uploadcare.com/api-refs/rest-api/v0.7.0/?utm_source=github&utm_campaign=uploadcare-js-api-clients
 [uc-file-tags]: https://uploadcare.com/docs/file-tags/
 [uc-file-search]: https://uploadcare.com/docs/file-search/
+[api-reference]: https://uploadcare.github.io/uploadcare-js-api-clients/rest-client/

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -214,9 +214,9 @@ page.results[0].uuid
 
 Full-text conditions are `query` (across searchable fields) and `phrase` (per
 field), both needing at least 4 characters, with `fuzziness: true` for typo
-tolerance. `exact` matches whole values, and its `metadata` keys are yours to
-name. Everything you write is camelCase; only your own metadata keys and tag
-values keep the spelling you gave them:
+tolerance. `exact` matches whole values. Everything you write is camelCase, and
+the client translates it to the API's own spelling; your metadata keys and tag
+values are the exception, and go out exactly as you wrote them:
 
 ```typescript
 const page = await searchFiles(
@@ -237,9 +237,9 @@ page.results[0].highlight?.originalFilename
 ```
 
 Pass `include: 'appdata'` to embed add-on data. A malformed or empty query
-rejects with a `RestClientValidationError`, which carries the server's
-complaints keyed by field. It extends `RestClientError`, so existing handling
-keeps working:
+rejects with a `RestClientValidationError`, which lists what the server objected
+to, keyed by field. It extends `RestClientError`, so a `catch` block that already
+checks for that still matches:
 
 ```typescript
 import {
@@ -258,12 +258,11 @@ try {
 ```
 
 Errors that span more than one field, and the empty-query case, arrive under
-`nonFieldErrors`. Field names are camelized like any other response, except a
-key naming your own metadata, which keeps the spelling you gave it.
+`nonFieldErrors`. Field names follow the same casing rule as the options.
 
 Results paginate through `limit` and `offset`, so `searchFiles` works with the
-[pagination helpers](#pagination) below — bearing in mind the API requires
-`offset + limit` to stay under 1000:
+[pagination helpers](#pagination) below. The API requires `offset + limit` to
+stay under 1000, which ends a walk at that point however many files match:
 
 ```typescript
 import { paginate, searchFiles } from '@uploadcare/rest-client'
@@ -278,10 +277,9 @@ for await (const page of pages) {
 }
 ```
 
-Newly uploaded files are indexed asynchronously, so a file may not be findable
-immediately after upload — expect a few seconds. See [docs][uc-file-search] for
-the full condition reference, and the [API Reference][api-reference] for every
-option and its type.
+Newly uploaded files are indexed asynchronously, so expect a few seconds before
+one turns up in results. See [docs][uc-file-search] for the full condition
+reference, and the [API Reference][api-reference] for every option and its type.
 
 ### Settings
 

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -16,6 +16,7 @@
 [![Uploadcare stack on StackShare][badge-stack-img]][badge-stack-url]
 
 <!-- toc -->
+
 - [Install](#install)
 - [Usage](#usage)
   - [Authentication](#authentication)
@@ -54,12 +55,15 @@ With the [`Uploadcare.Simple`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#
 Example:
 
 ```typescript
-import { listOfFiles, UploadcareSimpleAuthSchema } from '@uploadcare/rest-client';
+import {
+  listOfFiles,
+  UploadcareSimpleAuthSchema
+} from '@uploadcare/rest-client'
 
 const uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
 const result = await listOfFiles({}, { authSchema: uploadcareSimpleAuthSchema })
 ```
@@ -73,11 +77,11 @@ With the [`Uploadcare`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#section
 You can use the builtin signature resolver, which automatically generates signature in-place using `crypto` module at Node.js or Web Crypto API at browsers.
 
 ```typescript
-import { UploadcareAuthSchema } from '@uploadcare/rest-client';
+import { UploadcareAuthSchema } from '@uploadcare/rest-client'
 
 new UploadcareAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
+  secretKey: 'YOUR_SECRET_KEY'
 })
 ```
 
@@ -88,7 +92,7 @@ new UploadcareAuthSchema({
 This option is useful on the client-side to avoid secret key leak. You need to implement some backend endpoint, which will generate signature. In this case, secret key will be stored on your server only and will not be disclosed.
 
 ```typescript
-import { UploadcareAuthSchema } from '@uploadcare/rest-client';
+import { UploadcareAuthSchema } from '@uploadcare/rest-client'
 
 new UploadcareAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
@@ -97,9 +101,11 @@ new UploadcareAuthSchema({
      * You need to make HTTPS request to your backend endpoint,
      * which should sign the `signString` using secret key.
      */
-    const response = await fetch(`/sign-request?signString=${encodeURIComponent(signString)}`);
-    const signature = await response.text();
-    return signature;
+    const response = await fetch(
+      `/sign-request?signString=${encodeURIComponent(signString)}`
+    )
+    const signature = await response.text()
+    return signature
   }
 })
 ```
@@ -107,13 +113,15 @@ new UploadcareAuthSchema({
 And then somewhere on your backend:
 
 ```javascript
-import { createSignature } from '@uploadcare/rest-client';
+import { createSignature } from '@uploadcare/rest-client'
 
 app.get('/sign-request', async (req, res) => {
-  const signature = await createSignature('YOUR_SECREY_KEY', req.query.signString);
-  res.send(signature);
+  const signature = await createSignature(
+    'YOUR_SECREY_KEY',
+    req.query.signString
+  )
+  res.send(signature)
 })
-
 ```
 
 ### API
@@ -121,12 +129,15 @@ app.get('/sign-request', async (req, res) => {
 You can use low-level wrappers to call the API endpoints directly:
 
 ```typescript
-import { listOfFiles, UploadcareSimpleAuthSchema } from '@uploadcare/rest-client';
+import {
+  listOfFiles,
+  UploadcareSimpleAuthSchema
+} from '@uploadcare/rest-client'
 
 const uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
 const result = await listOfFiles({}, { authSchema: uploadcareSimpleAuthSchema })
 ```
@@ -145,24 +156,27 @@ import {
   replaceTags,
   updateTags,
   UploadcareSimpleAuthSchema
-} from '@uploadcare/rest-client';
+} from '@uploadcare/rest-client'
 
 const authSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
 // Read the current tags
-const { tags } = await getTags({ uuid: 'FILE_UUID' }, { authSchema });
+const { tags } = await getTags({ uuid: 'FILE_UUID' }, { authSchema })
 
 // Replace the entire tag set
-await replaceTags({ uuid: 'FILE_UUID', tags: ['cat', 'animal'] }, { authSchema });
+await replaceTags(
+  { uuid: 'FILE_UUID', tags: ['cat', 'animal'] },
+  { authSchema }
+)
 
 // Add and remove tags at once (delete is applied before add)
 const result = await updateTags(
   { uuid: 'FILE_UUID', add: ['dog', 'outdoor'], delete: ['cat'] },
   { authSchema }
-);
+)
 // result: { tags, added, deleted }
 ```
 
@@ -174,12 +188,15 @@ See [docs][uc-file-tags] for normalization rules and limits.
 least one is required, and conditions combine with AND:
 
 ```typescript
-import { searchFiles, UploadcareSimpleAuthSchema } from '@uploadcare/rest-client';
+import {
+  searchFiles,
+  UploadcareSimpleAuthSchema
+} from '@uploadcare/rest-client'
 
 const authSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
 const page = await searchFiles(
   {
@@ -189,16 +206,17 @@ const page = await searchFiles(
     limit: 50
   },
   { authSchema }
-);
+)
 
-page.total; // 42
-page.results[0].uuid;
+page.total // 42
+page.results[0].uuid
 ```
 
 Full-text conditions are `query` (across searchable fields) and `phrase` (per
 field), both needing at least 4 characters, with `fuzziness: true` for typo
 tolerance. `exact` matches whole values, and its `metadata` keys are yours to
-name:
+name. Field names inside `phrase`, `exact`, `sort` and `highlight` are the API's
+own, so one vocabulary covers filtering, sorting and highlighting:
 
 ```typescript
 const page = await searchFiles(
@@ -207,15 +225,15 @@ const page = await searchFiles(
       detected_mime_type: ['image/png'],
       metadata: { color: ['red', 'blue'] }
     },
-    phrase: { originalFilename: 'invoice' },
+    phrase: { original_filename: 'invoice' },
     datetimeUploaded: { gte: new Date('2026-01-01') },
     size: { gt: 1_000_000 }
   },
   { authSchema }
-);
+)
 
 // tokens that matched, wrapped in <em>
-page.results[0].highlight?.originalFilename;
+page.results[0].highlight?.original_filename
 ```
 
 Pass `include: 'appdata'` to embed add-on data. A malformed or empty query
@@ -224,14 +242,17 @@ complaints keyed by field. It extends `RestClientError`, so existing handling
 keeps working:
 
 ```typescript
-import { isRestClientValidationError, searchFiles } from '@uploadcare/rest-client';
+import {
+  isRestClientValidationError,
+  searchFiles
+} from '@uploadcare/rest-client'
 
 try {
-  await searchFiles({ query: 'abc' }, { authSchema });
+  await searchFiles({ query: 'abc' }, { authSchema })
 } catch (error) {
   if (isRestClientValidationError(error)) {
-    error.errors; // { query: ['Must be at least 4 characters.'] }
-    error.message; // '[400 Bad Request] query: Must be at least 4 characters.'
+    error.errors // { query: ['Must be at least 4 characters.'] }
+    error.message // '[400 Bad Request] query: Must be at least 4 characters.'
   }
 }
 ```
@@ -259,11 +280,14 @@ import { listOfFiles, paginate } from '@uploadcare/rest-client'
 
 const uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
 const paginatedListOfFiles = paginate(listOfFiles)
-const pages = paginatedListOfFiles({}, { authSchema: uploadcareSimpleAuthSchema })
+const pages = paginatedListOfFiles(
+  {},
+  { authSchema: uploadcareSimpleAuthSchema }
+)
 
 for await (const page of pages) {
   console.log(page)
@@ -277,17 +301,21 @@ import { listOfFiles, Paginator } from '@uploadcare/rest-client'
 
 const uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({
   publicKey: 'YOUR_PUBLIC_KEY',
-  secretKey: 'YOUR_SECRET_KEY',
-});
+  secretKey: 'YOUR_SECRET_KEY'
+})
 
-const paginator = new Paginator(listOfFiles, {}, { authSchema: uploadcareSimpleAuthSchema })
+const paginator = new Paginator(
+  listOfFiles,
+  {},
+  { authSchema: uploadcareSimpleAuthSchema }
+)
 
-while(paginator.hasNextPage()) {
+while (paginator.hasNextPage()) {
   const page = await paginator.next()
   console.log(page)
 }
 
-while(paginator.hasPrevPage()) {
+while (paginator.hasPrevPage()) {
   const page = await paginator.prev()
   console.log(page)
 }
@@ -322,8 +350,8 @@ const jobs = await conversionJobPoller(
   {
     type: ConversionType.VIDEO,
     // type: ConversionType.DOCUMENT,
-    onRun: response => console.log(response), // called when job is started
-    onStatus: response => console.log(response), // called on every job status request
+    onRun: (response) => console.log(response), // called when job is started
+    onStatus: (response) => console.log(response), // called on every job status request
     paths: [':uuid/video/-/size/x720/', ':uuid/video/-/size/x360/'],
     store: false,
     pollOptions: {
@@ -360,8 +388,8 @@ const result = await addonJobPoller(
     addonName: AddonName.UC_CLAMAV_VIRUS_SCAN,
     // addonName: AddonName.AWS_REKOGNITION_DETECT_LABELS,
     // addonName: AddonName.REMOVE_BG,
-    onRun: response => console.log(response), // called when job is started
-    onStatus: response => console.log(response), // called on every job status request
+    onRun: (response) => console.log(response), // called when job is started
+    onStatus: (response) => console.log(response), // called on every job status request
     target: ':uuid',
     params: {
       purge_infected: false

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -261,14 +261,21 @@ Errors that span more than one field, and the empty-query case, arrive under
 `nonFieldErrors`. Field names follow the same casing rule as the options.
 
 Results paginate through `limit` and `offset`, so `searchFiles` works with the
-[pagination helpers](#pagination) below. The API requires `offset + limit` to
-stay under 1000, which ends a walk at that point however many files match:
+[pagination helpers](#pagination) below. Pass an explicit `sort` when you
+paginate: the default relevance order is not stable between pages, so a walk
+without one can hand back a file an earlier page already gave you. The API also
+requires `offset + limit` to stay under 1000, which ends a walk at that point
+however many files match:
 
 ```typescript
 import { paginate, searchFiles } from '@uploadcare/rest-client'
 
 const pages = paginate(searchFiles)(
-  { tags: { any: ['cat'] }, limit: 100 },
+  {
+    tags: { any: ['cat'] },
+    sort: [{ field: 'datetimeUploaded', order: 'desc' }],
+    limit: 100
+  },
   { authSchema }
 )
 

--- a/packages/rest-client/src/.eslintrc.json
+++ b/packages/rest-client/src/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "env": {"es6": true, "node": true, "browser": true}
+  "env": { "es6": true, "node": true, "browser": true }
 }

--- a/packages/rest-client/src/api/file/searchFiles.test.ts
+++ b/packages/rest-client/src/api/file/searchFiles.test.ts
@@ -1,120 +1,319 @@
 import { describe, expect, it } from '@jest/globals'
 import { Paginator } from '../../tools/paginate'
 import { RestClientValidationError } from '../../tools/RestClientValidationError'
-import { searchFiles } from './searchFiles'
+import { searchFiles, SearchFilesOptions } from './searchFiles'
 
 import { testSettings } from '../../../test/helpers'
 
 /**
- * Assertions are about shape, not about which files come back: search indexes
- * newly uploaded files asynchronously, and the test project's contents are not
- * fixed, so asserting on results would flake for reasons unrelated to this
- * code.
+ * Assertions about matches are about shape, not about which files come back:
+ * search indexes newly uploaded files asynchronously and the test project's
+ * contents are not fixed, so asserting on results would flake for reasons
+ * unrelated to this code. The rejections below are exact, since they depend on
+ * the request alone.
  */
 describe('searchFiles', () => {
-  it('should return a paginated list for a full-text query', async () => {
-    const response = await searchFiles({ query: 'jpeg' }, testSettings)
-
-    expect(typeof response.total).toBe('number')
-    expect(Array.isArray(response.results)).toBe(true)
-    expect(typeof response.perPage).toBe('number')
-  })
-
-  it('should accept a combined tags, isImage and sort query', async () => {
-    const response = await searchFiles(
+  describe('conditions the api accepts', () => {
+    const accepted: { name: string; options: SearchFilesOptions }[] = [
+      { name: 'query', options: { query: 'jpeg' } },
       {
-        tags: { any: ['cat', 'animal'] },
-        isImage: true,
-        sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
-        limit: 5
+        name: 'phrase on the filename',
+        options: { phrase: { originalFilename: 'jpeg' } }
       },
-      testSettings
-    )
+      {
+        name: 'phrase on the mime type',
+        options: { phrase: { detectedMimeType: 'image' } }
+      },
+      {
+        name: 'phrase on metadata',
+        options: { phrase: { metadata: 'uploader' } }
+      },
+      { name: 'fuzziness', options: { query: 'jpeg', fuzziness: true } },
+      {
+        name: 'exact uuid',
+        options: { exact: { uuid: ['8c8d781b-a19d-4b7d-bc79-a808ba71fe30'] } }
+      },
+      {
+        name: 'exact mime type',
+        options: { exact: { detectedMimeType: ['image/jpeg'] } }
+      },
+      {
+        name: 'exact filename',
+        options: { exact: { originalFilename: ['nope.jpeg'] } }
+      },
+      {
+        name: 'exact metadata',
+        options: { exact: { metadata: { subsystem: ['uploader'] } } }
+      },
+      { name: 'isImage true', options: { isImage: true } },
+      { name: 'isImage false', options: { isImage: false } },
+      { name: 'size lower bound', options: { size: { gt: 0 } } },
+      { name: 'size range', options: { size: { gte: 1, lte: 100_000_000 } } },
+      {
+        name: 'datetimeUploaded from a Date',
+        options: {
+          datetimeUploaded: { gte: new Date('2000-01-01T00:00:00.000Z') }
+        }
+      },
+      {
+        name: 'datetimeUploaded from a string',
+        options: { datetimeUploaded: { lt: '2100-01-01T00:00:00.000Z' } }
+      },
+      { name: 'tags any', options: { tags: { any: ['cat', 'animal'] } } },
+      { name: 'tags all', options: { tags: { all: ['cat'] } } },
+      { name: 'tags none', options: { tags: { none: ['draft'] } } },
+      {
+        name: 'four sort keys',
+        options: {
+          isImage: true,
+          sort: [
+            { field: 'score', order: 'desc' },
+            { field: 'datetimeUploaded' },
+            { field: 'size', order: 'desc' },
+            { field: 'originalFilename' }
+          ]
+        }
+      },
+      {
+        name: 'every condition at once',
+        options: {
+          query: 'jpeg',
+          exact: { detectedMimeType: ['image/jpeg'] },
+          datetimeUploaded: { gte: new Date('2000-01-01T00:00:00.000Z') },
+          size: { gt: 0 },
+          isImage: true,
+          fuzziness: true,
+          tags: { none: ['draft'] },
+          sort: [{ field: 'datetimeUploaded', order: 'desc' }],
+          include: 'appdata'
+        }
+      }
+    ]
 
-    expect(typeof response.total).toBe('number')
-    for (const file of response.results) {
-      expect(file.uuid).toBeTruthy()
-      expect(file.isImage).toBe(true)
-    }
+    it.each(accepted)('should search by $name', async ({ options }) => {
+      const response = await searchFiles({ ...options, limit: 2 }, testSettings)
+
+      expect(typeof response.total).toBe('number')
+      expect(Array.isArray(response.results)).toBe(true)
+      expect(response.results.length).toBeLessThanOrEqual(2)
+      for (const file of response.results) {
+        expect(file.uuid).toBeTruthy()
+      }
+    })
   })
 
-  it('should accept exact conditions, including metadata keys', async () => {
-    const response = await searchFiles(
-      {
-        exact: {
-          detectedMimeType: ['image/jpeg'],
-          metadata: { subsystem: ['uploader'] }
+  describe('the page it returns', () => {
+    it('should report perPage as the limit asked for', async () => {
+      const response = await searchFiles(
+        { size: { gt: 0 }, limit: 3 },
+        testSettings
+      )
+
+      expect(response.perPage).toBe(3)
+      expect(response.results.length).toBeLessThanOrEqual(3)
+      expect(response.previous).toBeNull()
+    })
+
+    it('should link to a next page while one remains', async () => {
+      const response = await searchFiles(
+        { size: { gt: 0 }, limit: 1 },
+        testSettings
+      )
+
+      if (response.total > 1) {
+        expect(response.next).toContain('/files/search/')
+      }
+    })
+
+    // Sorted on purpose: relevance order is not stable between pages, so an
+    // unsorted walk can hand back a file it already gave you.
+    it('should walk to a second page of different files', async () => {
+      const paginator = new Paginator(
+        searchFiles,
+        {
+          size: { gt: 0 },
+          limit: 1,
+          sort: [{ field: 'datetimeUploaded', order: 'desc' }]
         },
-        limit: 1
-      },
-      testSettings
-    )
+        testSettings
+      )
 
-    expect(Array.isArray(response.results)).toBe(true)
+      const firstPage = await paginator.next()
+      expect(firstPage?.results.length).toBeLessThanOrEqual(1)
+
+      if (firstPage?.next) {
+        const secondPage = await paginator.next()
+        expect(secondPage?.results[0]?.uuid).not.toBe(
+          firstPage.results[0]?.uuid
+        )
+        expect(secondPage?.previous).toBeTruthy()
+      }
+    })
+
+    it('should carry appdata when asked to', async () => {
+      const response = await searchFiles(
+        { query: 'jpeg', include: 'appdata', limit: 1 },
+        testSettings
+      )
+
+      for (const file of response.results) {
+        expect(file).toHaveProperty('appdata')
+      }
+    })
+
+    it('should highlight the field a full-text condition matched', async () => {
+      const response = await searchFiles(
+        { phrase: { originalFilename: 'jpeg' }, limit: 1 },
+        testSettings
+      )
+
+      for (const file of response.results) {
+        expect(file.highlight?.originalFilename?.[0]).toContain('<em>')
+      }
+    })
+
+    it('should return an empty highlight when no full-text condition matched', async () => {
+      const response = await searchFiles(
+        { size: { gt: 0 }, limit: 1 },
+        testSettings
+      )
+
+      for (const file of response.results) {
+        expect(Object.keys(file.highlight ?? {})).toEqual([])
+      }
+    })
   })
 
-  it('should accept date and size ranges', async () => {
-    const response = await searchFiles(
+  /**
+   * Every rejection the endpoint documents, plus the ones its serializer adds.
+   * Each names the field it blames, camelized apart from a metadata key.
+   */
+  describe('conditions the api rejects', () => {
+    const rejected: {
+      name: string
+      options: SearchFilesOptions
+      /** The key the client reports it under, read literally. */
+      field: string
+    }[] = [
+      { name: 'no condition at all', options: {}, field: 'nonFieldErrors' },
       {
-        datetimeUploaded: { gte: new Date('2000-01-01T00:00:00.000Z') },
-        size: { gt: 0 },
-        limit: 1
+        name: 'a query under 4 characters',
+        options: { query: 'abc' },
+        field: 'query'
       },
-      testSettings
+      {
+        name: 'a phrase under 4 characters',
+        options: { phrase: { originalFilename: 'abc' } },
+        field: 'phrase.originalFilename'
+      },
+      {
+        name: 'the same field in phrase and exact',
+        options: {
+          phrase: { originalFilename: 'invoice' },
+          exact: { originalFilename: ['invoice.pdf'] }
+        },
+        field: 'nonFieldErrors'
+      },
+      { name: 'an empty tags object', options: { tags: {} }, field: 'tags' },
+      { name: 'a range with no bound', options: { size: {} }, field: 'size' },
+      {
+        name: 'a range that is not an object',
+        options: { size: 5 as unknown as { gt: number } },
+        field: 'size'
+      },
+      {
+        name: 'isImage that is not a boolean',
+        options: { isImage: 'yes' as unknown as boolean },
+        field: 'isImage'
+      },
+      {
+        name: 'a duplicate sort key',
+        options: {
+          isImage: true,
+          sort: [{ field: 'size' }, { field: 'size' }]
+        },
+        field: 'sort'
+      },
+      {
+        name: 'more than four sort keys',
+        options: {
+          isImage: true,
+          sort: [
+            { field: 'size' },
+            { field: 'score' },
+            { field: 'datetimeUploaded' },
+            { field: 'originalFilename' },
+            { field: 'size', order: 'desc' }
+          ]
+        },
+        field: 'sort'
+      },
+      {
+        name: 'an unknown sort key',
+        options: { isImage: true, sort: [{ field: 'nope' as never }] },
+        field: 'sort.0'
+      },
+      {
+        name: 'a limit below 1',
+        options: { isImage: true, limit: 0 },
+        field: 'limit'
+      },
+      {
+        name: 'a limit above 100',
+        options: { isImage: true, limit: 101 },
+        field: 'limit'
+      },
+      {
+        name: 'offset plus limit over 1000',
+        options: { isImage: true, limit: 100, offset: 950 },
+        field: 'offset'
+      }
+    ]
+
+    it.each(rejected)(
+      'should reject $name, blaming $field',
+      async ({ options, field }) => {
+        expect.assertions(4)
+        try {
+          await searchFiles(options, testSettings)
+        } catch (error) {
+          const validationError = error as RestClientValidationError
+          expect(validationError).toBeInstanceOf(RestClientValidationError)
+          expect(validationError.status).toBe(400)
+          // a literal key, so `toHaveProperty` would read the dot as a path
+          expect(Object.keys(validationError.errors)).toContain(field)
+          // the message is built from the same object, so it repeats the text
+          expect(validationError.message).toContain(
+            validationError.errors[field]?.[0]
+          )
+        }
+      }
     )
 
-    expect(typeof response.total).toBe('number')
-  })
+    it('should name the field in the message, not only in errors', async () => {
+      expect.assertions(2)
+      try {
+        await searchFiles({ query: 'abc' }, testSettings)
+      } catch (error) {
+        const validationError = error as RestClientValidationError
+        expect(validationError.message).toBe(
+          '[400 Bad Request] query: Must be at least 4 characters.'
+        )
+        expect(validationError.errors).toEqual({
+          query: ['Must be at least 4 characters.']
+        })
+      }
+    })
 
-  it('should embed appdata when asked to', async () => {
-    const response = await searchFiles(
-      { query: 'jpeg', include: 'appdata', limit: 1 },
-      testSettings
-    )
-
-    for (const file of response.results) {
-      expect(file).toHaveProperty('appdata')
-    }
-  })
-
-  it('should paginate through the Paginator', async () => {
-    const paginator = new Paginator(
-      searchFiles,
-      { size: { gt: 0 }, limit: 1 },
-      testSettings
-    )
-
-    const firstPage = await paginator.next()
-    expect(firstPage?.results.length).toBeLessThanOrEqual(1)
-
-    if (firstPage?.next) {
-      const secondPage = await paginator.next()
-      expect(secondPage?.results[0]?.uuid).not.toBe(firstPage.results[0]?.uuid)
-    }
-  })
-
-  it('should reject with the offending field named when a condition is malformed', async () => {
-    expect.assertions(4)
-    try {
-      await searchFiles({ size: 5 as unknown as { gt: number } }, testSettings)
-    } catch (error) {
-      const restClientError = error as RestClientValidationError
-      expect(restClientError).toBeInstanceOf(RestClientValidationError)
-      expect(restClientError.status).toBe(400)
-      expect(restClientError.message).toContain('size')
-      expect(restClientError.errors).toHaveProperty('size')
-    }
-  })
-
-  it('should reject when no condition is given at all', async () => {
-    expect.assertions(3)
-    try {
-      await searchFiles({}, testSettings)
-    } catch (error) {
-      const restClientError = error as RestClientValidationError
-      expect(restClientError).toBeInstanceOf(RestClientValidationError)
-      expect(restClientError.status).toBe(400)
-      expect(restClientError.errors).toHaveProperty('nonFieldErrors')
-    }
+    it('should report a missing condition without a field prefix', async () => {
+      expect.assertions(1)
+      try {
+        await searchFiles({}, testSettings)
+      } catch (error) {
+        expect((error as RestClientValidationError).message).toBe(
+          '[400 Bad Request] At least one search criterion must be specified.'
+        )
+      }
+    })
   })
 })

--- a/packages/rest-client/src/api/file/searchFiles.test.ts
+++ b/packages/rest-client/src/api/file/searchFiles.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
+import { makeApiRequest } from '../../makeApiRequest'
 import { Paginator } from '../../tools/paginate'
 import { RestClientError } from '../../tools/RestClientError'
 import { searchFiles } from './searchFiles'
@@ -96,15 +97,39 @@ describe('searchFiles', () => {
     }
   })
 
-  it('should reject with the offending field named when a condition is malformed', async () => {
-    expect.assertions(3)
+  // TEMPORARY: prints the real 400 body so the parser can be written against it
+  // rather than against the docs. Remove with the next commit.
+  it('DIAGNOSTIC: dumps the raw 400 response', async () => {
+    const { response } = await makeApiRequest(
+      { method: 'POST', path: '/files/search/', body: { size: 5 } },
+      testSettings
+    )
+
+    console.log('DIAGNOSTIC status:', response.status)
+    console.log(
+      'DIAGNOSTIC content-type:',
+      response.headers.get('content-type')
+    )
+    console.log('DIAGNOSTIC body:', await response.text())
+
+    const empty = await makeApiRequest(
+      { method: 'POST', path: '/files/search/', body: {} },
+      testSettings
+    )
+    console.log('DIAGNOSTIC empty status:', empty.response.status)
+    console.log('DIAGNOSTIC empty body:', await empty.response.text())
+
+    expect(response.status).toBe(400)
+  })
+
+  it('should reject with a 400 when a condition is malformed', async () => {
+    expect.assertions(2)
     try {
       await searchFiles({ size: 5 as unknown as { gt: number } }, testSettings)
     } catch (error) {
       const restClientError = error as RestClientError
       expect(restClientError).toBeInstanceOf(RestClientError)
       expect(restClientError.status).toBe(400)
-      expect(restClientError.message).toContain('size')
     }
   })
 

--- a/packages/rest-client/src/api/file/searchFiles.test.ts
+++ b/packages/rest-client/src/api/file/searchFiles.test.ts
@@ -25,10 +25,7 @@ describe('searchFiles', () => {
       {
         tags: { any: ['cat', 'animal'] },
         isImage: true,
-        sort: [
-          { field: 'datetime_uploaded', order: 'desc' },
-          { field: 'size' }
-        ],
+        sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
         limit: 5
       },
       testSettings
@@ -45,7 +42,7 @@ describe('searchFiles', () => {
     const response = await searchFiles(
       {
         exact: {
-          detected_mime_type: ['image/jpeg'],
+          detectedMimeType: ['image/jpeg'],
           metadata: { subsystem: ['uploader'] }
         },
         limit: 1
@@ -117,7 +114,7 @@ describe('searchFiles', () => {
       const restClientError = error as RestClientValidationError
       expect(restClientError).toBeInstanceOf(RestClientValidationError)
       expect(restClientError.status).toBe(400)
-      expect(restClientError.errors).toHaveProperty('non_field_errors')
+      expect(restClientError.errors).toHaveProperty('nonFieldErrors')
     }
   })
 })

--- a/packages/rest-client/src/api/file/searchFiles.test.ts
+++ b/packages/rest-client/src/api/file/searchFiles.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
-import { makeApiRequest } from '../../makeApiRequest'
 import { Paginator } from '../../tools/paginate'
-import { RestClientError } from '../../tools/RestClientError'
+import { RestClientValidationError } from '../../tools/RestClientValidationError'
 import { searchFiles } from './searchFiles'
 
 import { testSettings } from '../../../test/helpers'
@@ -46,7 +45,7 @@ describe('searchFiles', () => {
     const response = await searchFiles(
       {
         exact: {
-          detectedMimeType: ['image/jpeg'],
+          detected_mime_type: ['image/jpeg'],
           metadata: { subsystem: ['uploader'] }
         },
         limit: 1
@@ -97,43 +96,28 @@ describe('searchFiles', () => {
     }
   })
 
-  // TEMPORARY: prints the real 400 body so the parser can be written against it
-  // rather than against the docs. Remove with the next commit.
-  it('DIAGNOSTIC: dumps the raw 400 response', async () => {
-    const { response } = await makeApiRequest(
-      { method: 'POST', path: '/files/search/', body: { size: 5 } },
-      testSettings
-    )
-
-    console.log('DIAGNOSTIC status:', response.status)
-    console.log(
-      'DIAGNOSTIC content-type:',
-      response.headers.get('content-type')
-    )
-    console.log('DIAGNOSTIC body:', await response.text())
-
-    const empty = await makeApiRequest(
-      { method: 'POST', path: '/files/search/', body: {} },
-      testSettings
-    )
-    console.log('DIAGNOSTIC empty status:', empty.response.status)
-    console.log('DIAGNOSTIC empty body:', await empty.response.text())
-
-    expect(response.status).toBe(400)
-  })
-
-  it('should reject with a 400 when a condition is malformed', async () => {
-    expect.assertions(2)
+  it('should reject with the offending field named when a condition is malformed', async () => {
+    expect.assertions(4)
     try {
       await searchFiles({ size: 5 as unknown as { gt: number } }, testSettings)
     } catch (error) {
-      const restClientError = error as RestClientError
-      expect(restClientError).toBeInstanceOf(RestClientError)
+      const restClientError = error as RestClientValidationError
+      expect(restClientError).toBeInstanceOf(RestClientValidationError)
       expect(restClientError.status).toBe(400)
+      expect(restClientError.message).toContain('size')
+      expect(restClientError.errors).toHaveProperty('size')
     }
   })
 
   it('should reject when no condition is given at all', async () => {
-    await expect(searchFiles({}, testSettings)).rejects.toThrow(RestClientError)
+    expect.assertions(3)
+    try {
+      await searchFiles({}, testSettings)
+    } catch (error) {
+      const restClientError = error as RestClientValidationError
+      expect(restClientError).toBeInstanceOf(RestClientValidationError)
+      expect(restClientError.status).toBe(400)
+      expect(restClientError.errors).toHaveProperty('non_field_errors')
+    }
   })
 })

--- a/packages/rest-client/src/api/file/searchFiles.test.ts
+++ b/packages/rest-client/src/api/file/searchFiles.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from '@jest/globals'
+import { Paginator } from '../../tools/paginate'
+import { RestClientError } from '../../tools/RestClientError'
+import { searchFiles } from './searchFiles'
+
+import { testSettings } from '../../../test/helpers'
+
+/**
+ * Assertions are about shape, not about which files come back: search indexes
+ * newly uploaded files asynchronously, and the test project's contents are not
+ * fixed, so asserting on results would flake for reasons unrelated to this
+ * code.
+ */
+describe('searchFiles', () => {
+  it('should return a paginated list for a full-text query', async () => {
+    const response = await searchFiles({ query: 'jpeg' }, testSettings)
+
+    expect(typeof response.total).toBe('number')
+    expect(Array.isArray(response.results)).toBe(true)
+    expect(typeof response.perPage).toBe('number')
+  })
+
+  it('should accept a combined tags, isImage and sort query', async () => {
+    const response = await searchFiles(
+      {
+        tags: { any: ['cat', 'animal'] },
+        isImage: true,
+        sort: [
+          { field: 'datetime_uploaded', order: 'desc' },
+          { field: 'size' }
+        ],
+        limit: 5
+      },
+      testSettings
+    )
+
+    expect(typeof response.total).toBe('number')
+    for (const file of response.results) {
+      expect(file.uuid).toBeTruthy()
+      expect(file.isImage).toBe(true)
+    }
+  })
+
+  it('should accept exact conditions, including metadata keys', async () => {
+    const response = await searchFiles(
+      {
+        exact: {
+          detectedMimeType: ['image/jpeg'],
+          metadata: { subsystem: ['uploader'] }
+        },
+        limit: 1
+      },
+      testSettings
+    )
+
+    expect(Array.isArray(response.results)).toBe(true)
+  })
+
+  it('should accept date and size ranges', async () => {
+    const response = await searchFiles(
+      {
+        datetimeUploaded: { gte: new Date('2000-01-01T00:00:00.000Z') },
+        size: { gt: 0 },
+        limit: 1
+      },
+      testSettings
+    )
+
+    expect(typeof response.total).toBe('number')
+  })
+
+  it('should embed appdata when asked to', async () => {
+    const response = await searchFiles(
+      { query: 'jpeg', include: 'appdata', limit: 1 },
+      testSettings
+    )
+
+    for (const file of response.results) {
+      expect(file).toHaveProperty('appdata')
+    }
+  })
+
+  it('should paginate through the Paginator', async () => {
+    const paginator = new Paginator(
+      searchFiles,
+      { size: { gt: 0 }, limit: 1 },
+      testSettings
+    )
+
+    const firstPage = await paginator.next()
+    expect(firstPage?.results.length).toBeLessThanOrEqual(1)
+
+    if (firstPage?.next) {
+      const secondPage = await paginator.next()
+      expect(secondPage?.results[0]?.uuid).not.toBe(firstPage.results[0]?.uuid)
+    }
+  })
+
+  it('should reject with the offending field named when a condition is malformed', async () => {
+    expect.assertions(3)
+    try {
+      await searchFiles({ size: 5 as unknown as { gt: number } }, testSettings)
+    } catch (error) {
+      const restClientError = error as RestClientError
+      expect(restClientError).toBeInstanceOf(RestClientError)
+      expect(restClientError.status).toBe(400)
+      expect(restClientError.message).toContain('size')
+    }
+  })
+
+  it('should reject when no condition is given at all', async () => {
+    await expect(searchFiles({}, testSettings)).rejects.toThrow(RestClientError)
+  })
+})

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -18,11 +18,14 @@ export type SearchFilesExactMetadata = {
   [K in keyof Metadata]?: Metadata[K][]
 }
 
-/** Exact matching. A file matches a field if it equals any of its values. */
+/**
+ * Exact matching. A file matches a field if it equals any of its values. Field
+ * names are the API's own, as in `sort`.
+ */
 export type SearchFilesExact = {
   uuid?: string[]
-  detectedMimeType?: string[]
-  originalFilename?: string[]
+  detected_mime_type?: string[]
+  original_filename?: string[]
   metadata?: SearchFilesExactMetadata
 }
 

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -62,7 +62,7 @@ export type SearchFilesSort = {
 }
 
 /**
- * At least one condition is required — `query`, `phrase`, `exact`,
+ * At least one condition is required: `query`, `phrase`, `exact`,
  * `datetimeUploaded`, `size`, `isImage` or `tags`. Conditions combine with
  * AND.
  */
@@ -81,7 +81,7 @@ export type SearchFilesOptions = {
   tags?: SearchFilesTags
   /** Up to 4 keys, applied in the order given. Defaults to relevance. */
   sort?: SearchFilesSort[]
-  /** 1–100, defaults to 20. */
+  /** 1 to 100, defaults to 20. */
   limit?: number
   /** `offset + limit` must stay under 1000. */
   offset?: number

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -18,25 +18,21 @@ export type SearchFilesExactMetadata = {
   [K in keyof Metadata]?: Metadata[K][]
 }
 
-/**
- * Exact matching. A file matches a field if it equals any of its values. Field
- * names are the API's own, as in `sort`.
- */
+/** Exact matching. A file matches a field if it equals any of its values. */
 export type SearchFilesExact = {
   uuid?: string[]
-  detected_mime_type?: string[]
-  original_filename?: string[]
+  detectedMimeType?: string[]
+  originalFilename?: string[]
   metadata?: SearchFilesExactMetadata
 }
 
 /**
  * Full-text matching per field, each phrase at least 4 characters. A field used
- * here cannot also appear in {@link SearchFilesExact}, and the field names are
- * the same in both.
+ * here cannot also appear in {@link SearchFilesExact}.
  */
 export type SearchFilesPhrase = {
-  original_filename?: string
-  detected_mime_type?: string
+  originalFilename?: string
+  detectedMimeType?: string
   /** One phrase, matched across metadata values. */
   metadata?: string
 }
@@ -53,9 +49,9 @@ export type SearchFilesTags = {
 
 export type SearchFilesSortField =
   | 'score'
-  | 'datetime_uploaded'
+  | 'datetimeUploaded'
   | 'size'
-  | 'original_filename'
+  | 'originalFilename'
 
 export type SearchFilesSort = {
   field: SearchFilesSortField
@@ -92,13 +88,12 @@ export type SearchFilesOptions = {
 
 /**
  * Matched tokens, wrapped in `<em>`, for fields that matched a full-text
- * condition. Keys are the API's own, the same names `phrase` and `exact` take:
- * `highlight` is on the camelization ignore list, so one vocabulary covers
- * filtering and highlighting alike.
+ * condition. Field names arrive camelized like the rest of a response, while
+ * the keys inside `metadata` are yours and are left alone.
  */
 export type SearchFilesHighlight = {
-  original_filename?: string[]
-  detected_mime_type?: string[]
+  originalFilename?: string[]
+  detectedMimeType?: string[]
   /** Matched tokens per metadata key. */
   metadata?: Metadata
 }
@@ -123,7 +118,7 @@ export type SearchFilesResponse = PaginatedList<SearchFilesResult>
  *     {
  *       tags: { all: ['cat', 'animal'] },
  *       isImage: true,
- *       sort: [{ field: 'datetime_uploaded', order: 'desc' }]
+ *       sort: [{ field: 'datetimeUploaded', order: 'desc' }]
  *     },
  *     { authSchema }
  *   )

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -79,7 +79,11 @@ export type SearchFilesOptions = {
   /** Typo tolerance for `query` and `phrase`. Slower. Defaults to `false`. */
   fuzziness?: boolean
   tags?: SearchFilesTags
-  /** Up to 4 keys, applied in the order given. Defaults to relevance. */
+  /**
+   * Up to 4 keys, applied in the order given. Defaults to relevance, which is
+   * not stable between pages: give an explicit sort when paginating, or a page
+   * can repeat a file an earlier one already returned.
+   */
   sort?: SearchFilesSort[]
   /** 1 to 100, defaults to 20. */
   limit?: number

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -1,0 +1,146 @@
+import { Metadata, Tags } from '@uploadcare/api-client-utils'
+import { makeApiRequest, ApiRequestSettings } from '../../makeApiRequest'
+import { FileInfo } from '../../types/FileInfo'
+import { PaginatedList } from '../../types/PaginatedList'
+import { handleApiRequest } from '../handleApiRequest'
+import { toSearchBody } from './toSearchBody'
+
+/** Bounds for a range condition. The API requires at least one of them. */
+export type SearchFilesRange<T> = {
+  gt?: T
+  gte?: T
+  lt?: T
+  lte?: T
+}
+
+/** Candidate values per metadata key, sent as `metadata[key]`. */
+export type SearchFilesExactMetadata = {
+  [K in keyof Metadata]?: Metadata[K][]
+}
+
+/** Exact matching. A file matches a field if it equals any of its values. */
+export type SearchFilesExact = {
+  uuid?: string[]
+  detectedMimeType?: string[]
+  originalFilename?: string[]
+  metadata?: SearchFilesExactMetadata
+}
+
+/**
+ * Full-text matching per field, each phrase at least 4 characters. A field used
+ * here cannot also appear in {@link SearchFilesExact}.
+ */
+export type SearchFilesPhrase = {
+  originalFilename?: string
+  detectedMimeType?: string
+  /** One phrase, matched across metadata values. */
+  metadata?: string
+}
+
+/** Tag filters. Tags are lowercased and whitespace-stripped server-side. */
+export type SearchFilesTags = {
+  /** Has at least one of these tags. */
+  any?: Tags
+  /** Has all of these tags. */
+  all?: Tags
+  /** Has none of these tags. */
+  none?: Tags
+}
+
+export type SearchFilesSortField =
+  | 'score'
+  | 'datetime_uploaded'
+  | 'size'
+  | 'original_filename'
+
+export type SearchFilesSort = {
+  field: SearchFilesSortField
+  /** Defaults to `'asc'`. */
+  order?: 'asc' | 'desc'
+}
+
+/**
+ * At least one condition is required — `query`, `phrase`, `exact`,
+ * `datetimeUploaded`, `size`, `isImage` or `tags`. Conditions combine with
+ * AND.
+ */
+export type SearchFilesOptions = {
+  /** Full-text across searchable fields, at least 4 characters. */
+  query?: string
+  phrase?: SearchFilesPhrase
+  exact?: SearchFilesExact
+  datetimeUploaded?: SearchFilesRange<Date | string>
+  /** File size in bytes. */
+  size?: SearchFilesRange<number>
+  /** `false` excludes images. */
+  isImage?: boolean
+  /** Typo tolerance for `query` and `phrase`. Slower. Defaults to `false`. */
+  fuzziness?: boolean
+  tags?: SearchFilesTags
+  /** Up to 4 keys, applied in the order given. Defaults to relevance. */
+  sort?: SearchFilesSort[]
+  /** 1–100, defaults to 20. */
+  limit?: number
+  /** `offset + limit` must stay under 1000. */
+  offset?: number
+  include?: 'appdata'
+}
+
+/**
+ * Matched tokens, wrapped in `<em>`, for fields that matched a full-text
+ * condition.
+ */
+export type SearchFilesHighlight = {
+  originalFilename?: string[]
+  detectedMimeType?: string[]
+  /** Matched tokens per metadata key. */
+  metadata?: Metadata
+}
+
+export type SearchFilesResult = FileInfo & {
+  highlight?: SearchFilesHighlight
+}
+
+export type SearchFilesResponse = PaginatedList<SearchFilesResult>
+
+/**
+ * Searches the project's files. Paginates through `limit` and `offset`, so it
+ * works with {@link paginate} and `Paginator`, up to the API's ceiling of
+ * `offset + limit < 1000`.
+ *
+ * Newly uploaded files are indexed asynchronously and may not be found straight
+ * away.
+ *
+ * @example
+ *   ;```ts
+ *   const page = await searchFiles(
+ *     {
+ *       tags: { all: ['cat', 'animal'] },
+ *       isImage: true,
+ *       sort: [{ field: 'datetime_uploaded', order: 'desc' }]
+ *     },
+ *     { authSchema }
+ *   )
+ *   ```
+ *
+ * @see https://uploadcare.com/docs/api/rest/file/search-files/
+ */
+export async function searchFiles(
+  options: SearchFilesOptions,
+  userSettings: ApiRequestSettings
+): Promise<SearchFilesResponse> {
+  const apiRequest = await makeApiRequest(
+    {
+      method: 'POST',
+      path: '/files/search/',
+      query: {
+        limit: options.limit,
+        offset: options.offset,
+        include: options.include
+      },
+      body: toSearchBody(options)
+    },
+    userSettings
+  )
+  return handleApiRequest({ apiRequest, okCodes: [200] })
+}

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -31,11 +31,12 @@ export type SearchFilesExact = {
 
 /**
  * Full-text matching per field, each phrase at least 4 characters. A field used
- * here cannot also appear in {@link SearchFilesExact}.
+ * here cannot also appear in {@link SearchFilesExact}, and the field names are
+ * the same in both.
  */
 export type SearchFilesPhrase = {
-  originalFilename?: string
-  detectedMimeType?: string
+  original_filename?: string
+  detected_mime_type?: string
   /** One phrase, matched across metadata values. */
   metadata?: string
 }
@@ -91,11 +92,13 @@ export type SearchFilesOptions = {
 
 /**
  * Matched tokens, wrapped in `<em>`, for fields that matched a full-text
- * condition.
+ * condition. Keys are the API's own, the same names `phrase` and `exact` take:
+ * `highlight` is on the camelization ignore list, so one vocabulary covers
+ * filtering and highlighting alike.
  */
 export type SearchFilesHighlight = {
-  originalFilename?: string[]
-  detectedMimeType?: string[]
+  original_filename?: string[]
+  detected_mime_type?: string[]
   /** Matched tokens per metadata key. */
   metadata?: Metadata
 }

--- a/packages/rest-client/src/api/file/searchFiles.ts
+++ b/packages/rest-client/src/api/file/searchFiles.ts
@@ -47,12 +47,14 @@ export type SearchFilesTags = {
   none?: Tags
 }
 
+/** Sort keys the API accepts, spelled as this client spells them. */
 export type SearchFilesSortField =
   | 'score'
   | 'datetimeUploaded'
   | 'size'
   | 'originalFilename'
 
+/** One sort key. Several are applied in the order given. */
 export type SearchFilesSort = {
   field: SearchFilesSortField
   /** Defaults to `'asc'`. */
@@ -98,10 +100,15 @@ export type SearchFilesHighlight = {
   metadata?: Metadata
 }
 
+/** A file as search returns it: the usual fields, plus what matched. */
 export type SearchFilesResult = FileInfo & {
   highlight?: SearchFilesHighlight
 }
 
+/**
+ * One page of results. Satisfies {@link Paginatable}, so {@link paginate} and
+ * {@link Paginator} accept {@link searchFiles}.
+ */
 export type SearchFilesResponse = PaginatedList<SearchFilesResult>
 
 /**
@@ -113,7 +120,6 @@ export type SearchFilesResponse = PaginatedList<SearchFilesResult>
  * away.
  *
  * @example
- *   ;```ts
  *   const page = await searchFiles(
  *     {
  *       tags: { all: ['cat', 'animal'] },
@@ -122,8 +128,15 @@ export type SearchFilesResponse = PaginatedList<SearchFilesResult>
  *     },
  *     { authSchema }
  *   )
- *   ```
  *
+ * @param options - Search conditions, and `limit`/`offset`/`include`. At least
+ *   one condition is required.
+ * @param userSettings - Auth schema and any request settings.
+ * @returns One page of matching files, newest-first by relevance unless `sort`
+ *   says otherwise.
+ * @throws {@link RestClientValidationError} When a condition is malformed or
+ *   none is given; its `errors` name the fields.
+ * @see https://uploadcare.com/docs/file-search/
  * @see https://uploadcare.com/docs/api/rest/file/search-files/
  */
 export async function searchFiles(

--- a/packages/rest-client/src/api/file/toSearchBody.test.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from '@jest/globals'
+import type { SearchFilesOptions, SearchFilesSortField } from './searchFiles'
 import { toSearchBody } from './toSearchBody'
+
+const BOUNDS = ['gt', 'gte', 'lt', 'lte'] as const
+
+const SORT_TOKENS: [SearchFilesSortField, string][] = [
+  ['score', 'score'],
+  ['datetimeUploaded', 'datetime_uploaded'],
+  ['size', 'size'],
+  ['originalFilename', 'original_filename']
+]
 
 describe('toSearchBody', () => {
   it('should send nothing for empty options', () => {
@@ -13,97 +23,193 @@ describe('toSearchBody', () => {
     })
   })
 
+  it('should keep fuzziness false rather than dropping it', () => {
+    expect(toSearchBody({ fuzziness: false })).toEqual({ fuzziness: false })
+  })
+
   it('should map isImage to is_image, including false', () => {
+    expect(toSearchBody({ isImage: true })).toEqual({ is_image: true })
     expect(toSearchBody({ isImage: false })).toEqual({ is_image: false })
   })
 
-  it('should map phrase fields to their api keys', () => {
-    expect(
-      toSearchBody({
+  describe('phrase', () => {
+    it('should map every field to its api key', () => {
+      expect(
+        toSearchBody({
+          phrase: {
+            originalFilename: 'invoice',
+            detectedMimeType: 'image',
+            metadata: 'red'
+          }
+        })
+      ).toEqual({
         phrase: {
-          originalFilename: 'invoice',
-          detectedMimeType: 'image',
+          original_filename: 'invoice',
+          detected_mime_type: 'image',
           metadata: 'red'
         }
       })
-    ).toEqual({
-      phrase: {
-        original_filename: 'invoice',
-        detected_mime_type: 'image',
-        metadata: 'red'
-      }
+    })
+
+    it.each([
+      [{ originalFilename: 'invoice' }, { original_filename: 'invoice' }],
+      [{ detectedMimeType: 'image' }, { detected_mime_type: 'image' }],
+      [{ metadata: 'red' }, { metadata: 'red' }]
+    ])('should send %s on its own', (phrase, expected) => {
+      expect(toSearchBody({ phrase })).toEqual({ phrase: expected })
     })
   })
 
-  it('should map exact fields and flatten metadata into metadata[key] siblings', () => {
-    expect(
-      toSearchBody({
+  describe('exact', () => {
+    it('should map every field and flatten metadata into metadata[key] siblings', () => {
+      expect(
+        toSearchBody({
+          exact: {
+            uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
+            detectedMimeType: ['image/png'],
+            originalFilename: ['logo.png'],
+            metadata: { color: ['red', 'blue'], sku: ['A1'] }
+          }
+        })
+      ).toEqual({
         exact: {
           uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
-          detectedMimeType: ['image/png'],
-          originalFilename: ['logo.png'],
-          metadata: { color: ['red', 'blue'], sku: ['A1'] }
+          detected_mime_type: ['image/png'],
+          original_filename: ['logo.png'],
+          'metadata[color]': ['red', 'blue'],
+          'metadata[sku]': ['A1']
         }
       })
-    ).toEqual({
-      exact: {
-        uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
-        detected_mime_type: ['image/png'],
-        original_filename: ['logo.png'],
-        'metadata[color]': ['red', 'blue'],
-        'metadata[sku]': ['A1']
-      }
+    })
+
+    it('should keep several candidate values per field', () => {
+      expect(
+        toSearchBody({
+          exact: { detectedMimeType: ['image/png', 'image/webp', 'image/avif'] }
+        })
+      ).toEqual({
+        exact: {
+          detected_mime_type: ['image/png', 'image/webp', 'image/avif']
+        }
+      })
+    })
+
+    it('should copy metadata keys verbatim, without camelizing or decamelizing them', () => {
+      expect(
+        toSearchBody({ exact: { metadata: { my_key: ['a'], myKey: ['b'] } } })
+      ).toEqual({
+        exact: { 'metadata[my_key]': ['a'], 'metadata[myKey]': ['b'] }
+      })
+    })
+
+    it('should send an empty exact object as one, letting the api reject it', () => {
+      expect(toSearchBody({ exact: {} })).toEqual({ exact: {} })
+      expect(toSearchBody({ exact: { metadata: {} } })).toEqual({ exact: {} })
     })
   })
 
-  it('should copy metadata keys verbatim, without camelizing or decamelizing them', () => {
-    expect(
-      toSearchBody({ exact: { metadata: { my_key: ['a'], myKey: ['b'] } } })
-    ).toEqual({
-      exact: { 'metadata[my_key]': ['a'], 'metadata[myKey]': ['b'] }
+  describe('ranges', () => {
+    it.each(BOUNDS)('should send size.%s on its own', (bound) => {
+      expect(toSearchBody({ size: { [bound]: 1000 } })).toEqual({
+        size: { [bound]: 1000 }
+      })
     })
-  })
 
-  it('should turn dates in datetimeUploaded bounds into iso strings', () => {
-    expect(
-      toSearchBody({
-        datetimeUploaded: {
-          gte: new Date('2026-01-01T00:00:00.000Z'),
+    it.each(BOUNDS)('should send datetimeUploaded.%s on its own', (bound) => {
+      expect(
+        toSearchBody({
+          datetimeUploaded: { [bound]: new Date('2026-01-01T00:00:00.000Z') }
+        })
+      ).toEqual({ datetime_uploaded: { [bound]: '2026-01-01T00:00:00.000Z' } })
+    })
+
+    it('should combine bounds into one range', () => {
+      expect(toSearchBody({ size: { gt: 1000, lte: 5000 } })).toEqual({
+        size: { gt: 1000, lte: 5000 }
+      })
+    })
+
+    it('should keep a zero bound rather than dropping it', () => {
+      expect(toSearchBody({ size: { gte: 0 } })).toEqual({ size: { gte: 0 } })
+    })
+
+    it('should accept an iso string as well as a Date', () => {
+      expect(
+        toSearchBody({
+          datetimeUploaded: {
+            gte: new Date('2026-01-01T00:00:00.000Z'),
+            lt: '2026-07-01T00:00:00.000Z'
+          }
+        })
+      ).toEqual({
+        datetime_uploaded: {
+          gte: '2026-01-01T00:00:00.000Z',
           lt: '2026-07-01T00:00:00.000Z'
         }
       })
-    ).toEqual({
-      datetime_uploaded: {
-        gte: '2026-01-01T00:00:00.000Z',
-        lt: '2026-07-01T00:00:00.000Z'
+    })
+
+    it('should send an empty range as one, letting the api reject it', () => {
+      expect(toSearchBody({ size: {} })).toEqual({ size: {} })
+    })
+  })
+
+  describe('tags', () => {
+    it.each(['any', 'all', 'none'] as const)(
+      'should pass the %s group through',
+      (group) => {
+        expect(toSearchBody({ tags: { [group]: ['cat'] } })).toEqual({
+          tags: { [group]: ['cat'] }
+        })
       }
-    })
-  })
+    )
 
-  it('should pass size bounds through as numbers', () => {
-    expect(toSearchBody({ size: { gt: 1000000, lte: 5000000 } })).toEqual({
-      size: { gt: 1000000, lte: 5000000 }
-    })
-  })
-
-  it('should pass tags groups through', () => {
-    expect(
-      toSearchBody({ tags: { all: ['cat', 'animal'], none: ['draft'] } })
-    ).toEqual({ tags: { all: ['cat', 'animal'], none: ['draft'] } })
-  })
-
-  it('should turn sort entries into tokens, in order, prefixing descending ones', () => {
-    expect(
-      toSearchBody({
-        sort: [
-          { field: 'datetimeUploaded', order: 'desc' },
-          { field: 'size' },
-          { field: 'originalFilename', order: 'asc' },
-          { field: 'score', order: 'desc' }
-        ]
+    it('should pass all three groups together', () => {
+      expect(
+        toSearchBody({
+          tags: { any: ['cat'], all: ['animal', 'pet'], none: ['draft'] }
+        })
+      ).toEqual({
+        tags: { any: ['cat'], all: ['animal', 'pet'], none: ['draft'] }
       })
-    ).toEqual({
-      sort: ['-datetime_uploaded', 'size', 'original_filename', '-score']
+    })
+
+    it('should keep an empty tag list, since the api has an opinion about it', () => {
+      expect(toSearchBody({ tags: { all: [] } })).toEqual({ tags: { all: [] } })
+    })
+  })
+
+  describe('sort', () => {
+    it.each(SORT_TOKENS)(
+      'should turn %s into its api token, ascending and descending',
+      (field, token) => {
+        expect(toSearchBody({ sort: [{ field }] })).toEqual({ sort: [token] })
+        expect(toSearchBody({ sort: [{ field, order: 'asc' }] })).toEqual({
+          sort: [token]
+        })
+        expect(toSearchBody({ sort: [{ field, order: 'desc' }] })).toEqual({
+          sort: [`-${token}`]
+        })
+      }
+    )
+
+    it('should keep the order the caller gave, which is the sort priority', () => {
+      expect(
+        toSearchBody({
+          sort: [
+            { field: 'datetimeUploaded', order: 'desc' },
+            { field: 'size' },
+            { field: 'originalFilename', order: 'asc' },
+            { field: 'score', order: 'desc' }
+          ]
+        })
+      ).toEqual({
+        sort: ['-datetime_uploaded', 'size', 'original_filename', '-score']
+      })
+    })
+
+    it('should send an empty sort list as one', () => {
+      expect(toSearchBody({ sort: [] })).toEqual({ sort: [] })
     })
   })
 
@@ -123,28 +229,43 @@ describe('toSearchBody', () => {
     expect(Object.keys(body.exact as object)).not.toContain('original_filename')
   })
 
-  it('should never put limit, offset or include in the body', () => {
+  it.each(['limit', 'offset', 'include'] as const)(
+    'should never put %s in the body',
+    (key) => {
+      const body = toSearchBody({
+        query: 'invoice',
+        [key]: key === 'include' ? 'appdata' : 10
+      } as SearchFilesOptions)
+
+      expect(body).toEqual({ query: 'invoice' })
+    }
+  )
+
+  it('should map every condition at once', () => {
     expect(
       toSearchBody({
         query: 'invoice',
+        phrase: { originalFilename: 'receipt' },
+        exact: { uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'] },
+        datetimeUploaded: { gte: new Date('2026-01-01T00:00:00.000Z') },
+        size: { gt: 1000 },
+        isImage: true,
+        fuzziness: true,
+        tags: { all: ['cat', 'animal'], none: ['draft'] },
+        sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
         limit: 50,
         offset: 100,
         include: 'appdata'
       })
-    ).toEqual({ query: 'invoice' })
-  })
-
-  it('should map the combined tags + isImage + sort query', () => {
-    expect(
-      toSearchBody({
-        tags: { all: ['cat', 'animal'], none: ['draft'] },
-        isImage: true,
-        sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
-        limit: 50
-      })
     ).toEqual({
-      tags: { all: ['cat', 'animal'], none: ['draft'] },
+      query: 'invoice',
+      phrase: { original_filename: 'receipt' },
+      exact: { uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'] },
+      datetime_uploaded: { gte: '2026-01-01T00:00:00.000Z' },
+      size: { gt: 1000 },
       is_image: true,
+      fuzziness: true,
+      tags: { all: ['cat', 'animal'], none: ['draft'] },
       sort: ['-datetime_uploaded', 'size']
     })
   })

--- a/packages/rest-client/src/api/file/toSearchBody.test.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from '@jest/globals'
+import { toSearchBody } from './toSearchBody'
+
+describe('toSearchBody', () => {
+  it('should send nothing for empty options', () => {
+    expect(toSearchBody({})).toEqual({})
+  })
+
+  it('should keep query and fuzziness as they are', () => {
+    expect(toSearchBody({ query: 'invoice', fuzziness: true })).toEqual({
+      query: 'invoice',
+      fuzziness: true
+    })
+  })
+
+  it('should map isImage to is_image, including false', () => {
+    expect(toSearchBody({ isImage: false })).toEqual({ is_image: false })
+  })
+
+  it('should map phrase fields to their api keys', () => {
+    expect(
+      toSearchBody({
+        phrase: {
+          originalFilename: 'invoice',
+          detectedMimeType: 'image',
+          metadata: 'red'
+        }
+      })
+    ).toEqual({
+      phrase: {
+        original_filename: 'invoice',
+        detected_mime_type: 'image',
+        metadata: 'red'
+      }
+    })
+  })
+
+  it('should map exact fields and flatten metadata into metadata[key] siblings', () => {
+    expect(
+      toSearchBody({
+        exact: {
+          uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
+          detectedMimeType: ['image/png'],
+          originalFilename: ['logo.png'],
+          metadata: { color: ['red', 'blue'], sku: ['A1'] }
+        }
+      })
+    ).toEqual({
+      exact: {
+        uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
+        detected_mime_type: ['image/png'],
+        original_filename: ['logo.png'],
+        'metadata[color]': ['red', 'blue'],
+        'metadata[sku]': ['A1']
+      }
+    })
+  })
+
+  it('should copy metadata keys verbatim, without camelizing or decamelizing them', () => {
+    expect(
+      toSearchBody({ exact: { metadata: { my_key: ['a'], myKey: ['b'] } } })
+    ).toEqual({
+      exact: { 'metadata[my_key]': ['a'], 'metadata[myKey]': ['b'] }
+    })
+  })
+
+  it('should turn dates in datetimeUploaded bounds into iso strings', () => {
+    expect(
+      toSearchBody({
+        datetimeUploaded: {
+          gte: new Date('2026-01-01T00:00:00.000Z'),
+          lt: '2026-07-01T00:00:00.000Z'
+        }
+      })
+    ).toEqual({
+      datetime_uploaded: {
+        gte: '2026-01-01T00:00:00.000Z',
+        lt: '2026-07-01T00:00:00.000Z'
+      }
+    })
+  })
+
+  it('should pass size bounds through as numbers', () => {
+    expect(toSearchBody({ size: { gt: 1000000, lte: 5000000 } })).toEqual({
+      size: { gt: 1000000, lte: 5000000 }
+    })
+  })
+
+  it('should pass tags groups through', () => {
+    expect(
+      toSearchBody({ tags: { all: ['cat', 'animal'], none: ['draft'] } })
+    ).toEqual({ tags: { all: ['cat', 'animal'], none: ['draft'] } })
+  })
+
+  it('should turn sort entries into tokens, in order, prefixing descending ones', () => {
+    expect(
+      toSearchBody({
+        sort: [
+          { field: 'datetime_uploaded', order: 'desc' },
+          { field: 'size' },
+          { field: 'original_filename', order: 'asc' },
+          { field: 'score', order: 'desc' }
+        ]
+      })
+    ).toEqual({
+      sort: ['-datetime_uploaded', 'size', 'original_filename', '-score']
+    })
+  })
+
+  it('should omit keys whose option is undefined rather than sending null', () => {
+    const body = toSearchBody({
+      query: 'invoice',
+      isImage: undefined,
+      tags: undefined,
+      exact: { detectedMimeType: ['image/png'], originalFilename: undefined }
+    })
+
+    expect(body).toEqual({
+      query: 'invoice',
+      exact: { detected_mime_type: ['image/png'] }
+    })
+    expect(Object.keys(body)).not.toContain('is_image')
+    expect(Object.keys(body.exact as object)).not.toContain('original_filename')
+  })
+
+  it('should never put limit, offset or include in the body', () => {
+    expect(
+      toSearchBody({
+        query: 'invoice',
+        limit: 50,
+        offset: 100,
+        include: 'appdata'
+      })
+    ).toEqual({ query: 'invoice' })
+  })
+
+  it('should map the combined tags + isImage + sort query', () => {
+    expect(
+      toSearchBody({
+        tags: { all: ['cat', 'animal'], none: ['draft'] },
+        isImage: true,
+        sort: [
+          { field: 'datetime_uploaded', order: 'desc' },
+          { field: 'size' }
+        ],
+        limit: 50
+      })
+    ).toEqual({
+      tags: { all: ['cat', 'animal'], none: ['draft'] },
+      is_image: true,
+      sort: ['-datetime_uploaded', 'size']
+    })
+  })
+})

--- a/packages/rest-client/src/api/file/toSearchBody.test.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.test.ts
@@ -40,8 +40,8 @@ describe('toSearchBody', () => {
       toSearchBody({
         exact: {
           uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
-          detectedMimeType: ['image/png'],
-          originalFilename: ['logo.png'],
+          detected_mime_type: ['image/png'],
+          original_filename: ['logo.png'],
           metadata: { color: ['red', 'blue'], sku: ['A1'] }
         }
       })
@@ -112,7 +112,7 @@ describe('toSearchBody', () => {
       query: 'invoice',
       isImage: undefined,
       tags: undefined,
-      exact: { detectedMimeType: ['image/png'], originalFilename: undefined }
+      exact: { detected_mime_type: ['image/png'], original_filename: undefined }
     })
 
     expect(body).toEqual({

--- a/packages/rest-client/src/api/file/toSearchBody.test.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.test.ts
@@ -21,8 +21,8 @@ describe('toSearchBody', () => {
     expect(
       toSearchBody({
         phrase: {
-          original_filename: 'invoice',
-          detected_mime_type: 'image',
+          originalFilename: 'invoice',
+          detectedMimeType: 'image',
           metadata: 'red'
         }
       })
@@ -40,8 +40,8 @@ describe('toSearchBody', () => {
       toSearchBody({
         exact: {
           uuid: ['d8cb0d0b-7820-448a-804f-0770ca1894e7'],
-          detected_mime_type: ['image/png'],
-          original_filename: ['logo.png'],
+          detectedMimeType: ['image/png'],
+          originalFilename: ['logo.png'],
           metadata: { color: ['red', 'blue'], sku: ['A1'] }
         }
       })
@@ -96,9 +96,9 @@ describe('toSearchBody', () => {
     expect(
       toSearchBody({
         sort: [
-          { field: 'datetime_uploaded', order: 'desc' },
+          { field: 'datetimeUploaded', order: 'desc' },
           { field: 'size' },
-          { field: 'original_filename', order: 'asc' },
+          { field: 'originalFilename', order: 'asc' },
           { field: 'score', order: 'desc' }
         ]
       })
@@ -112,7 +112,7 @@ describe('toSearchBody', () => {
       query: 'invoice',
       isImage: undefined,
       tags: undefined,
-      exact: { detected_mime_type: ['image/png'], original_filename: undefined }
+      exact: { detectedMimeType: ['image/png'], originalFilename: undefined }
     })
 
     expect(body).toEqual({
@@ -139,10 +139,7 @@ describe('toSearchBody', () => {
       toSearchBody({
         tags: { all: ['cat', 'animal'], none: ['draft'] },
         isImage: true,
-        sort: [
-          { field: 'datetime_uploaded', order: 'desc' },
-          { field: 'size' }
-        ],
+        sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
         limit: 50
       })
     ).toEqual({

--- a/packages/rest-client/src/api/file/toSearchBody.test.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.test.ts
@@ -21,8 +21,8 @@ describe('toSearchBody', () => {
     expect(
       toSearchBody({
         phrase: {
-          originalFilename: 'invoice',
-          detectedMimeType: 'image',
+          original_filename: 'invoice',
+          detected_mime_type: 'image',
           metadata: 'red'
         }
       })

--- a/packages/rest-client/src/api/file/toSearchBody.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.ts
@@ -1,0 +1,86 @@
+import type {
+  SearchFilesExact,
+  SearchFilesOptions,
+  SearchFilesPhrase,
+  SearchFilesRange,
+  SearchFilesSort
+} from './searchFiles'
+
+/** Drops keys the caller left out, so a present key always means a condition. */
+const defined = <Value>(
+  source: Record<string, Value | undefined>
+): Record<string, Value> =>
+  Object.fromEntries(
+    Object.entries(source).filter(([, value]) => value !== undefined)
+  ) as Record<string, Value>
+
+/** `field` is already the API's own token, so only the direction is added. */
+const toSortTokens = (sort: SearchFilesSort[]): string[] =>
+  sort.map(({ field, order }) => `${order === 'desc' ? '-' : ''}${field}`)
+
+const toIsoBounds = (
+  range: SearchFilesRange<Date | string>
+): SearchFilesRange<string> =>
+  Object.fromEntries(
+    Object.entries(defined(range)).map(([bound, value]) => [
+      bound,
+      value instanceof Date ? value.toISOString() : value
+    ])
+  )
+
+/**
+ * The API has no nested metadata object: it addresses one metadata key with a
+ * literal `metadata[key]` key of `exact` itself. The caller's keys are copied
+ * into the brackets verbatim — only the fixed field names are rewritten.
+ */
+const toExact = ({
+  uuid,
+  detectedMimeType,
+  originalFilename,
+  metadata
+}: SearchFilesExact): Record<string, string[]> =>
+  defined({
+    uuid,
+    detected_mime_type: detectedMimeType,
+    original_filename: originalFilename,
+    ...Object.fromEntries(
+      Object.entries(metadata ?? {}).map(([key, values]) => [
+        `metadata[${key}]`,
+        values
+      ])
+    )
+  })
+
+const toPhrase = ({
+  originalFilename,
+  detectedMimeType,
+  metadata
+}: SearchFilesPhrase): Record<string, string> =>
+  defined({
+    original_filename: originalFilename,
+    detected_mime_type: detectedMimeType,
+    metadata
+  })
+
+/**
+ * Builds the `POST /files/search/` request body from the options.
+ *
+ * `makeApiRequest` sends bodies verbatim, so the API's own key names are
+ * written here. `limit`, `offset` and `include` are query params and never
+ * appear in the body.
+ */
+export const toSearchBody = (
+  options: SearchFilesOptions
+): Record<string, unknown> =>
+  defined({
+    query: options.query,
+    phrase: options.phrase && toPhrase(options.phrase),
+    exact: options.exact && toExact(options.exact),
+    datetime_uploaded:
+      options.datetimeUploaded && toIsoBounds(options.datetimeUploaded),
+    size: options.size && defined(options.size),
+    is_image: options.isImage,
+    fuzziness: options.fuzziness,
+    tags: options.tags && defined(options.tags),
+    sort: options.sort && toSortTokens(options.sort)
+  })

--- a/packages/rest-client/src/api/file/toSearchBody.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.ts
@@ -48,16 +48,9 @@ const toExact = ({
     )
   })
 
-const toPhrase = ({
-  originalFilename,
-  detectedMimeType,
-  metadata
-}: SearchFilesPhrase): Record<string, string> =>
-  defined({
-    original_filename: originalFilename,
-    detected_mime_type: detectedMimeType,
-    metadata
-  })
+/** Field names already match the API, so only absent ones are dropped. */
+const toPhrase = (phrase: SearchFilesPhrase): Record<string, string> =>
+  defined(phrase)
 
 /**
  * Builds the `POST /files/search/` request body from the options.

--- a/packages/rest-client/src/api/file/toSearchBody.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.ts
@@ -29,20 +29,17 @@ const toIsoBounds = (
   )
 
 /**
- * The API has no nested metadata object: it addresses one metadata key with a
- * literal `metadata[key]` key of `exact` itself. The caller's keys are copied
- * into the brackets verbatim — only the fixed field names are rewritten.
+ * Field names are already the API's own, so only `metadata` moves: the API has
+ * no nested metadata object, it addresses one metadata key with a literal
+ * `metadata[key]` key of `exact` itself. The caller's keys are copied into the
+ * brackets verbatim.
  */
 const toExact = ({
-  uuid,
-  detectedMimeType,
-  originalFilename,
-  metadata
+  metadata,
+  ...fields
 }: SearchFilesExact): Record<string, string[]> =>
   defined({
-    uuid,
-    detected_mime_type: detectedMimeType,
-    original_filename: originalFilename,
+    ...fields,
     ...Object.fromEntries(
       Object.entries(metadata ?? {}).map(([key, values]) => [
         `metadata[${key}]`,

--- a/packages/rest-client/src/api/file/toSearchBody.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.ts
@@ -41,8 +41,7 @@ const toIsoBounds = (
 /**
  * The API has no nested metadata object: it addresses one metadata key with a
  * literal `metadata[key]` key of `exact` itself. The caller's metadata keys are
- * copied into the brackets verbatim — only the fixed field names are
- * rewritten.
+ * copied into the brackets verbatim. Only the fixed field names are rewritten.
  */
 const toExact = ({
   uuid,

--- a/packages/rest-client/src/api/file/toSearchBody.ts
+++ b/packages/rest-client/src/api/file/toSearchBody.ts
@@ -3,8 +3,17 @@ import type {
   SearchFilesOptions,
   SearchFilesPhrase,
   SearchFilesRange,
-  SearchFilesSort
+  SearchFilesSort,
+  SearchFilesSortField
 } from './searchFiles'
+
+/** The API's own sort tokens, which callers never have to spell. */
+const SORT_FIELDS: Record<SearchFilesSortField, string> = {
+  score: 'score',
+  datetimeUploaded: 'datetime_uploaded',
+  size: 'size',
+  originalFilename: 'original_filename'
+}
 
 /** Drops keys the caller left out, so a present key always means a condition. */
 const defined = <Value>(
@@ -14,9 +23,10 @@ const defined = <Value>(
     Object.entries(source).filter(([, value]) => value !== undefined)
   ) as Record<string, Value>
 
-/** `field` is already the API's own token, so only the direction is added. */
 const toSortTokens = (sort: SearchFilesSort[]): string[] =>
-  sort.map(({ field, order }) => `${order === 'desc' ? '-' : ''}${field}`)
+  sort.map(
+    ({ field, order }) => `${order === 'desc' ? '-' : ''}${SORT_FIELDS[field]}`
+  )
 
 const toIsoBounds = (
   range: SearchFilesRange<Date | string>
@@ -29,17 +39,21 @@ const toIsoBounds = (
   )
 
 /**
- * Field names are already the API's own, so only `metadata` moves: the API has
- * no nested metadata object, it addresses one metadata key with a literal
- * `metadata[key]` key of `exact` itself. The caller's keys are copied into the
- * brackets verbatim.
+ * The API has no nested metadata object: it addresses one metadata key with a
+ * literal `metadata[key]` key of `exact` itself. The caller's metadata keys are
+ * copied into the brackets verbatim — only the fixed field names are
+ * rewritten.
  */
 const toExact = ({
-  metadata,
-  ...fields
+  uuid,
+  detectedMimeType,
+  originalFilename,
+  metadata
 }: SearchFilesExact): Record<string, string[]> =>
   defined({
-    ...fields,
+    uuid,
+    detected_mime_type: detectedMimeType,
+    original_filename: originalFilename,
     ...Object.fromEntries(
       Object.entries(metadata ?? {}).map(([key, values]) => [
         `metadata[${key}]`,
@@ -48,9 +62,16 @@ const toExact = ({
     )
   })
 
-/** Field names already match the API, so only absent ones are dropped. */
-const toPhrase = (phrase: SearchFilesPhrase): Record<string, string> =>
-  defined(phrase)
+const toPhrase = ({
+  originalFilename,
+  detectedMimeType,
+  metadata
+}: SearchFilesPhrase): Record<string, string> =>
+  defined({
+    original_filename: originalFilename,
+    detected_mime_type: detectedMimeType,
+    metadata
+  })
 
 /**
  * Builds the `POST /files/search/` request body from the options.

--- a/packages/rest-client/src/api/handleApiRequest.test.ts
+++ b/packages/rest-client/src/api/handleApiRequest.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from '@jest/globals'
 import { Request, Response } from '../lib/fetch/fetch.node'
 import { RestClientError } from '../tools/RestClientError'
+import {
+  isRestClientValidationError,
+  RestClientValidationError
+} from '../tools/RestClientValidationError'
 import { handleApiRequest } from './handleApiRequest'
 
 const jsonResponse = (body: unknown, status: number) =>
@@ -34,15 +38,16 @@ describe('handleApiRequest', () => {
     await expect(promise).rejects.toMatchObject({ status: 404 })
   })
 
-  it('should leave errors undefined for a detail body', async () => {
-    expect.assertions(1)
+  it('should throw a plain RestClientError for a detail body', async () => {
+    expect.assertions(2)
     try {
       await handleApiRequest({
         apiRequest: apiRequestOf({ detail: 'file not found' }, 404),
         okCodes: [200]
       })
     } catch (error) {
-      expect((error as RestClientError).errors).toBeUndefined()
+      expect(error).toBeInstanceOf(RestClientError)
+      expect(isRestClientValidationError(error)).toBe(false)
     }
   })
 
@@ -60,13 +65,67 @@ describe('handleApiRequest', () => {
         okCodes: [200]
       })
     } catch (error) {
-      const restClientError = error as RestClientError
+      const restClientError = error as RestClientValidationError
       expect(restClientError.message).toBe(
         '[400 Bad Request] size: value must be an object; sort: too many keys, unknown key'
       )
       expect(restClientError.errors).toEqual({
         size: ['value must be an object'],
         sort: ['too many keys', 'unknown key']
+      })
+    }
+  })
+
+  // Both bodies below were captured from POST /files/search/, which nests one
+  // level deeper than the API docs describe.
+  it('should read a complaint nested under the field it belongs to', async () => {
+    expect.assertions(2)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          {
+            size: {
+              non_field_errors: [
+                'Invalid data. Expected a dictionary, but got int.'
+              ]
+            }
+          },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      const restClientError = error as RestClientValidationError
+      expect(restClientError.message).toBe(
+        '[400 Bad Request] size: Invalid data. Expected a dictionary, but got int.'
+      )
+      expect(restClientError.errors).toEqual({
+        size: ['Invalid data. Expected a dictionary, but got int.']
+      })
+    }
+  })
+
+  it('should report top-level non_field_errors without a field prefix', async () => {
+    expect.assertions(2)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          {
+            non_field_errors: [
+              'At least one search criterion must be specified.'
+            ]
+          },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      const restClientError = error as RestClientValidationError
+      expect(restClientError.message).toBe(
+        '[400 Bad Request] At least one search criterion must be specified.'
+      )
+      expect(restClientError.errors).toEqual({
+        non_field_errors: ['At least one search criterion must be specified.']
       })
     }
   })
@@ -79,11 +138,30 @@ describe('handleApiRequest', () => {
         okCodes: [200]
       })
     } catch (error) {
-      const restClientError = error as RestClientError
       // Unchanged from before this fallback existed: with no message to add,
       // RestClientError does not repeat the status text.
-      expect(restClientError.message).toBe('[400] Bad Request')
-      expect(restClientError.errors).toBeUndefined()
+      expect((error as RestClientError).message).toBe('[400] Bad Request')
+      expect(isRestClientValidationError(error)).toBe(false)
+    }
+  })
+
+  it('should throw a validation error that is still a RestClientError', async () => {
+    expect.assertions(4)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          { query: ['Must be at least 4 characters.'] },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      expect(error).toBeInstanceOf(RestClientValidationError)
+      expect(error).toBeInstanceOf(RestClientError)
+      expect(isRestClientValidationError(error)).toBe(true)
+      expect((error as RestClientValidationError).name).toBe(
+        'RestClientValidationError'
+      )
     }
   })
 })

--- a/packages/rest-client/src/api/handleApiRequest.test.ts
+++ b/packages/rest-client/src/api/handleApiRequest.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from '@jest/globals'
+import { Request, Response } from '../lib/fetch/fetch.node'
+import { RestClientError } from '../tools/RestClientError'
+import { handleApiRequest } from './handleApiRequest'
+
+const jsonResponse = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  })
+
+const apiRequestOf = (body: unknown, status: number) => ({
+  request: new Request('https://api.uploadcare.com/files/search/'),
+  response: jsonResponse(body, status) as unknown as Response
+})
+
+describe('handleApiRequest', () => {
+  it('should camelize a successful response', async () => {
+    const result = await handleApiRequest({
+      apiRequest: apiRequestOf({ per_page: 20, results: [] }, 200),
+      okCodes: [200]
+    })
+
+    expect(result).toEqual({ perPage: 20, results: [] })
+  })
+
+  it('should use detail as the message, unchanged', async () => {
+    const promise = handleApiRequest({
+      apiRequest: apiRequestOf({ detail: 'file not found' }, 404),
+      okCodes: [200]
+    })
+
+    await expect(promise).rejects.toThrow('file not found')
+    await expect(promise).rejects.toMatchObject({ status: 404 })
+  })
+
+  it('should leave errors undefined for a detail body', async () => {
+    expect.assertions(1)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf({ detail: 'file not found' }, 404),
+        okCodes: [200]
+      })
+    } catch (error) {
+      expect((error as RestClientError).errors).toBeUndefined()
+    }
+  })
+
+  it('should name the offending fields when the body carries per-field errors', async () => {
+    expect.assertions(2)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          {
+            size: ['value must be an object'],
+            sort: ['too many keys', 'unknown key']
+          },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      const restClientError = error as RestClientError
+      expect(restClientError.message).toBe(
+        '[400 Bad Request] size: value must be an object; sort: too many keys, unknown key'
+      )
+      expect(restClientError.errors).toEqual({
+        size: ['value must be an object'],
+        sort: ['too many keys', 'unknown key']
+      })
+    }
+  })
+
+  it('should fall back to the status when an error body is neither shape', async () => {
+    expect.assertions(2)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf({ whatever: 'not an array' }, 400),
+        okCodes: [200]
+      })
+    } catch (error) {
+      const restClientError = error as RestClientError
+      // Unchanged from before this fallback existed: with no message to add,
+      // RestClientError does not repeat the status text.
+      expect(restClientError.message).toBe('[400] Bad Request')
+      expect(restClientError.errors).toBeUndefined()
+    }
+  })
+})

--- a/packages/rest-client/src/api/handleApiRequest.test.ts
+++ b/packages/rest-client/src/api/handleApiRequest.test.ts
@@ -125,7 +125,7 @@ describe('handleApiRequest', () => {
         '[400 Bad Request] At least one search criterion must be specified.'
       )
       expect(restClientError.errors).toEqual({
-        non_field_errors: ['At least one search criterion must be specified.']
+        nonFieldErrors: ['At least one search criterion must be specified.']
       })
     }
   })
@@ -162,6 +162,27 @@ describe('handleApiRequest', () => {
       expect((error as RestClientValidationError).name).toBe(
         'RestClientValidationError'
       )
+    }
+  })
+
+  it('should camelize field names but leave metadata keys alone', async () => {
+    expect.assertions(1)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          {
+            datetime_uploaded: { non_field_errors: ['Invalid date.'] },
+            exact: { 'metadata[my_key]': ['Not a list.'] }
+          },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      expect((error as RestClientValidationError).errors).toEqual({
+        datetimeUploaded: ['Invalid date.'],
+        'exact.metadata[my_key]': ['Not a list.']
+      })
     }
   })
 })

--- a/packages/rest-client/src/api/handleApiRequest.test.ts
+++ b/packages/rest-client/src/api/handleApiRequest.test.ts
@@ -130,16 +130,22 @@ describe('handleApiRequest', () => {
     }
   })
 
-  it('should fall back to the status when an error body is neither shape', async () => {
+  // A string or an array of them is a complaint about a field; anything else is
+  // some other kind of body, and the message stays what it was before this
+  // fallback existed: RestClientError does not repeat the status text.
+  it.each([
+    ['a value that is neither string nor array', { whatever: 42 }],
+    ['an array at the root', ['nope']],
+    ['a body with no keys', {}],
+    ['mixed leaves, one of them unreadable', { size: ['too small'], n: 42 }]
+  ])('should fall back to the status given %s', async (_name, body) => {
     expect.assertions(2)
     try {
       await handleApiRequest({
-        apiRequest: apiRequestOf({ whatever: 'not an array' }, 400),
+        apiRequest: apiRequestOf(body, 400),
         okCodes: [200]
       })
     } catch (error) {
-      // Unchanged from before this fallback existed: with no message to add,
-      // RestClientError does not repeat the status text.
       expect((error as RestClientError).message).toBe('[400] Bad Request')
       expect(isRestClientValidationError(error)).toBe(false)
     }
@@ -182,6 +188,41 @@ describe('handleApiRequest', () => {
       expect((error as RestClientValidationError).errors).toEqual({
         datetimeUploaded: ['Invalid date.'],
         'exact.metadata[my_key]': ['Not a list.']
+      })
+    }
+  })
+
+  it('should read a complaint sent as a bare string, not an array', async () => {
+    expect.assertions(2)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf({ is_image: 'Must be a boolean value.' }, 400),
+        okCodes: [200]
+      })
+    } catch (error) {
+      const restClientError = error as RestClientValidationError
+      expect(restClientError.message).toBe(
+        '[400 Bad Request] isImage: Must be a boolean value.'
+      )
+      expect(restClientError.errors).toEqual({
+        isImage: ['Must be a boolean value.']
+      })
+    }
+  })
+
+  it('should read a complaint keyed by list index', async () => {
+    expect.assertions(1)
+    try {
+      await handleApiRequest({
+        apiRequest: apiRequestOf(
+          { sort: { 0: ['"nope" is not a valid choice.'] } },
+          400
+        ),
+        okCodes: [200]
+      })
+    } catch (error) {
+      expect((error as RestClientValidationError).errors).toEqual({
+        'sort.0': ['"nope" is not a valid choice.']
       })
     }
   })

--- a/packages/rest-client/src/api/handleApiRequest.ts
+++ b/packages/rest-client/src/api/handleApiRequest.ts
@@ -11,7 +11,13 @@ type HandleResponseOptions = {
   camelize?: boolean
 }
 
-const CAMELIZE_IGNORE_KEYS = ['metadata', 'problems', 'appdata']
+/**
+ * Sub-objects whose keys are not ours to rewrite: `metadata` keys are the
+ * caller's own, `appdata` and `problems` mirror add-on payloads, and
+ * `highlight` names the same search fields that `phrase` and `exact` take, so
+ * rewriting it would spell one field two ways in a single round trip.
+ */
+const CAMELIZE_IGNORE_KEYS = ['metadata', 'problems', 'appdata', 'highlight']
 const NO_CONTENT_STATUS = 204
 
 const isJsonContentType = (type: string | null) =>

--- a/packages/rest-client/src/api/handleApiRequest.ts
+++ b/packages/rest-client/src/api/handleApiRequest.ts
@@ -2,10 +2,8 @@ import { camelizeKeys } from '@uploadcare/api-client-utils'
 import { ApiRequest } from '../makeApiRequest'
 import { getAcceptHeader } from '../tools/getAcceptHeader'
 import { RestClientError } from '../tools/RestClientError'
-import {
-  ServerErrorResponse,
-  ServerValidationErrorResponse
-} from '../types/ServerErrorResponse'
+import { RestClientValidationError } from '../tools/RestClientValidationError'
+import { ServerErrorResponse } from '../types/ServerErrorResponse'
 
 type HandleResponseOptions = {
   apiRequest: ApiRequest
@@ -18,32 +16,6 @@ const NO_CONTENT_STATUS = 204
 
 const isJsonContentType = (type: string | null) =>
   type && ['application/json', getAcceptHeader()].includes(type)
-
-/**
- * Some endpoints answer a validation failure with errors keyed by field instead
- * of a `detail` string — `POST /files/search/` is one. Without this the details
- * would be dropped and the message would degrade to the bare status.
- */
-const getValidationErrors = (
-  json: unknown
-): ServerValidationErrorResponse | undefined => {
-  if (!json || typeof json !== 'object' || Array.isArray(json)) {
-    return undefined
-  }
-  const entries = Object.entries(json)
-  const isFieldErrors =
-    entries.length > 0 &&
-    entries.every(
-      ([, value]) =>
-        Array.isArray(value) && value.every((item) => typeof item === 'string')
-    )
-  return isFieldErrors ? (json as ServerValidationErrorResponse) : undefined
-}
-
-const formatValidationErrors = (errors: ServerValidationErrorResponse) =>
-  Object.entries(errors)
-    .map(([field, messages]) => `${field}: ${messages.join(', ')}`)
-    .join('; ')
 
 export async function handleApiRequest<ResponseType>(
   options: HandleResponseOptions
@@ -63,15 +35,11 @@ export async function handleApiRequest<ResponseType>(
   const json: unknown = await response.json()
   if (!okCodes.includes(response.status)) {
     const { detail } = json as ServerErrorResponse
-    const errors = detail === undefined ? getValidationErrors(json) : undefined
-    throw new RestClientError(
-      detail ?? (errors && formatValidationErrors(errors)),
-      {
-        response,
-        request,
-        errors
-      }
-    )
+    const errors = detail === undefined && RestClientValidationError.parse(json)
+    if (errors) {
+      throw new RestClientValidationError(errors, { response, request })
+    }
+    throw new RestClientError(detail, { response, request })
   }
 
   if (!camelize) {

--- a/packages/rest-client/src/api/handleApiRequest.ts
+++ b/packages/rest-client/src/api/handleApiRequest.ts
@@ -2,7 +2,10 @@ import { camelizeKeys } from '@uploadcare/api-client-utils'
 import { ApiRequest } from '../makeApiRequest'
 import { getAcceptHeader } from '../tools/getAcceptHeader'
 import { RestClientError } from '../tools/RestClientError'
-import { ServerErrorResponse } from '../types/ServerErrorResponse'
+import {
+  ServerErrorResponse,
+  ServerValidationErrorResponse
+} from '../types/ServerErrorResponse'
 
 type HandleResponseOptions = {
   apiRequest: ApiRequest
@@ -15,6 +18,32 @@ const NO_CONTENT_STATUS = 204
 
 const isJsonContentType = (type: string | null) =>
   type && ['application/json', getAcceptHeader()].includes(type)
+
+/**
+ * Some endpoints answer a validation failure with errors keyed by field instead
+ * of a `detail` string — `POST /files/search/` is one. Without this the details
+ * would be dropped and the message would degrade to the bare status.
+ */
+const getValidationErrors = (
+  json: unknown
+): ServerValidationErrorResponse | undefined => {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    return undefined
+  }
+  const entries = Object.entries(json)
+  const isFieldErrors =
+    entries.length > 0 &&
+    entries.every(
+      ([, value]) =>
+        Array.isArray(value) && value.every((item) => typeof item === 'string')
+    )
+  return isFieldErrors ? (json as ServerValidationErrorResponse) : undefined
+}
+
+const formatValidationErrors = (errors: ServerValidationErrorResponse) =>
+  Object.entries(errors)
+    .map(([field, messages]) => `${field}: ${messages.join(', ')}`)
+    .join('; ')
 
 export async function handleApiRequest<ResponseType>(
   options: HandleResponseOptions
@@ -33,10 +62,16 @@ export async function handleApiRequest<ResponseType>(
   }
   const json: unknown = await response.json()
   if (!okCodes.includes(response.status)) {
-    throw new RestClientError((json as ServerErrorResponse).detail, {
-      response,
-      request
-    })
+    const { detail } = json as ServerErrorResponse
+    const errors = detail === undefined ? getValidationErrors(json) : undefined
+    throw new RestClientError(
+      detail ?? (errors && formatValidationErrors(errors)),
+      {
+        response,
+        request,
+        errors
+      }
+    )
   }
 
   if (!camelize) {

--- a/packages/rest-client/src/api/handleApiRequest.ts
+++ b/packages/rest-client/src/api/handleApiRequest.ts
@@ -12,12 +12,10 @@ type HandleResponseOptions = {
 }
 
 /**
- * Sub-objects whose keys are not ours to rewrite: `metadata` keys are the
- * caller's own, `appdata` and `problems` mirror add-on payloads, and
- * `highlight` names the same search fields that `phrase` and `exact` take, so
- * rewriting it would spell one field two ways in a single round trip.
+ * Sub-objects whose keys are the caller's own data rather than the API's
+ * vocabulary, so rewriting them would corrupt what the caller stored.
  */
-const CAMELIZE_IGNORE_KEYS = ['metadata', 'problems', 'appdata', 'highlight']
+const CAMELIZE_IGNORE_KEYS = ['metadata', 'problems', 'appdata']
 const NO_CONTENT_STATUS = 204
 
 const isJsonContentType = (type: string | null) =>

--- a/packages/rest-client/src/index.ts
+++ b/packages/rest-client/src/index.ts
@@ -30,7 +30,10 @@ export { FileInfo, FileInfoVariations } from './types/FileInfo'
 export { GroupInfo, GroupInfoShort } from './types/GroupInfo'
 export { PaginatedList } from './types/PaginatedList'
 export { Problems } from './types/Problems'
-export { ServerErrorResponse } from './types/ServerErrorResponse'
+export {
+  ServerErrorResponse,
+  ServerValidationErrorResponse
+} from './types/ServerErrorResponse'
 export { Webhook } from './types/Webhook'
 export { WebhookEvent } from './types/WebhookEvent'
 export { StoreValue, CancelError } from '@uploadcare/api-client-utils'
@@ -137,6 +140,20 @@ export {
   ListOfFilesOrdering,
   ListOfFilesTotals
 } from './api/file/listOfFiles'
+export {
+  searchFiles,
+  SearchFilesOptions,
+  SearchFilesResponse,
+  SearchFilesResult,
+  SearchFilesExact,
+  SearchFilesExactMetadata,
+  SearchFilesHighlight,
+  SearchFilesPhrase,
+  SearchFilesRange,
+  SearchFilesSort,
+  SearchFilesSortField,
+  SearchFilesTags
+} from './api/file/searchFiles'
 export {
   storeFile,
   StoreFileResponse,

--- a/packages/rest-client/src/index.ts
+++ b/packages/rest-client/src/index.ts
@@ -82,9 +82,14 @@ export { getUserAgent } from '@uploadcare/api-client-utils'
 
 /** Tools */
 export {
+  isRestClientError,
   RestClientError,
   RestClientErrorOptions
 } from './tools/RestClientError'
+export {
+  isRestClientValidationError,
+  RestClientValidationError
+} from './tools/RestClientValidationError'
 export { paginate, Paginator } from './tools/paginate'
 export { addonJobPoller, AddonJobPollerOptions } from './tools/addonJobPoller'
 export {

--- a/packages/rest-client/src/tools/RestClientError.ts
+++ b/packages/rest-client/src/tools/RestClientError.ts
@@ -3,11 +3,6 @@ import { UploadcareError } from '@uploadcare/api-client-utils'
 export type RestClientErrorOptions = {
   request?: Request
   response?: Response
-  /**
-   * Validation errors keyed by field, when the server sent them instead of a
-   * `detail` string.
-   */
-  errors?: Record<string, string[]>
 }
 
 const DEFAULT_MESSAGE = 'Unknown error'
@@ -23,20 +18,12 @@ export class RestClientError extends UploadcareError {
   readonly request?: Request
   readonly response?: Response
 
-  /**
-   * Validation errors keyed by field, present when the server sent them instead
-   * of a `detail` string — `POST /files/search/` answers a 400 that way. The
-   * message names the same fields; this is for branching on them.
-   */
-  readonly errors?: Record<string, string[]>
-
   constructor(message?: string | null, options: RestClientErrorOptions = {}) {
     super()
 
     this.name = 'RestClientError'
     this.request = options.request
     this.response = options.response
-    this.errors = options.errors
 
     this.status = options.response?.status
     this.statusText = options.response?.statusText
@@ -53,3 +40,19 @@ export class RestClientError extends UploadcareError {
     Object.setPrototypeOf(this, RestClientError.prototype)
   }
 }
+
+/**
+ * Narrows a caught value, which TypeScript types as `unknown`, without a cast.
+ * True for subclasses too, {@link RestClientValidationError} among them.
+ *
+ * @example
+ *   ;```ts
+ *   catch (error) {
+ *     if (isRestClientError(error)) {
+ *       error.status // typed
+ *     }
+ *   }
+ *   ```
+ */
+export const isRestClientError = (error: unknown): error is RestClientError =>
+  error instanceof RestClientError

--- a/packages/rest-client/src/tools/RestClientError.ts
+++ b/packages/rest-client/src/tools/RestClientError.ts
@@ -1,13 +1,22 @@
 import { UploadcareError } from '@uploadcare/api-client-utils'
 
 export type RestClientErrorOptions = {
+  /** The signed request, when one was built. */
   request?: Request
+  /** The response, when one arrived; `status` is read from it. */
   response?: Response
 }
 
 const DEFAULT_MESSAGE = 'Unknown error'
 
 /**
+ * Anything that went wrong in a request: a transport failure, a non-2xx status,
+ * or a missing setting. `status` and `response` are absent for the failures
+ * that never reached the API.
+ *
+ * {@link RestClientValidationError} extends this for the case where the server
+ * rejected the request's contents and said which fields were at fault.
+ *
  * TODO: it's better to split errors into something like Runtime error and
  * ServerError (RestApiError)
  */
@@ -46,13 +55,14 @@ export class RestClientError extends UploadcareError {
  * True for subclasses too, {@link RestClientValidationError} among them.
  *
  * @example
- *   ;```ts
  *   catch (error) {
- *     if (isRestClientError(error)) {
- *       error.status // typed
- *     }
+ *   if (isRestClientError(error)) {
+ *   error.status // typed
  *   }
- *   ```
+ *   }
+ *
+ * @param error - Any caught value.
+ * @returns Whether it is a `RestClientError` or a subclass of one.
  */
 export const isRestClientError = (error: unknown): error is RestClientError =>
   error instanceof RestClientError

--- a/packages/rest-client/src/tools/RestClientError.ts
+++ b/packages/rest-client/src/tools/RestClientError.ts
@@ -3,6 +3,11 @@ import { UploadcareError } from '@uploadcare/api-client-utils'
 export type RestClientErrorOptions = {
   request?: Request
   response?: Response
+  /**
+   * Validation errors keyed by field, when the server sent them instead of a
+   * `detail` string.
+   */
+  errors?: Record<string, string[]>
 }
 
 const DEFAULT_MESSAGE = 'Unknown error'
@@ -18,12 +23,20 @@ export class RestClientError extends UploadcareError {
   readonly request?: Request
   readonly response?: Response
 
+  /**
+   * Validation errors keyed by field, present when the server sent them instead
+   * of a `detail` string — `POST /files/search/` answers a 400 that way. The
+   * message names the same fields; this is for branching on them.
+   */
+  readonly errors?: Record<string, string[]>
+
   constructor(message?: string | null, options: RestClientErrorOptions = {}) {
     super()
 
     this.name = 'RestClientError'
     this.request = options.request
     this.response = options.response
+    this.errors = options.errors
 
     this.status = options.response?.status
     this.statusText = options.response?.statusText

--- a/packages/rest-client/src/tools/RestClientValidationError.ts
+++ b/packages/rest-client/src/tools/RestClientValidationError.ts
@@ -5,8 +5,12 @@ import { ServerValidationErrorResponse } from '../types/ServerErrorResponse'
 /** As the server spells it; the key it becomes is {@link NON_FIELD_ERRORS}. */
 const SERVER_NON_FIELD_ERRORS = 'non_field_errors'
 
-/** Errors that belong to a level rather than to one of its fields. */
-const NON_FIELD_ERRORS = 'nonFieldErrors'
+/**
+ * Errors that belong to a level rather than to one of its fields. Derived, so
+ * the two spellings cannot drift: `camelizeString` reports the camelCase
+ * literal, making this `'nonFieldErrors'` to the type system as well.
+ */
+const NON_FIELD_ERRORS = camelizeString(SERVER_NON_FIELD_ERRORS)
 
 /**
  * Field names become camelCase like everything else the client hands back, with

--- a/packages/rest-client/src/tools/RestClientValidationError.ts
+++ b/packages/rest-client/src/tools/RestClientValidationError.ts
@@ -1,8 +1,21 @@
+import { camelizeString } from '@uploadcare/api-client-utils'
 import { RestClientError, RestClientErrorOptions } from './RestClientError'
 import { ServerValidationErrorResponse } from '../types/ServerErrorResponse'
 
+/** As the server spells it; the key it becomes is {@link NON_FIELD_ERRORS}. */
+const SERVER_NON_FIELD_ERRORS = 'non_field_errors'
+
 /** Errors that belong to a level rather than to one of its fields. */
-const NON_FIELD_ERRORS = 'non_field_errors'
+const NON_FIELD_ERRORS = 'nonFieldErrors'
+
+/**
+ * Field names become camelCase like everything else the client hands back, with
+ * one exception: a segment addressing the caller's own data, `metadata[color]`,
+ * is theirs to spell. Camelizing it would produce `metadataColor` and lose both
+ * the key and the form.
+ */
+const toFieldName = (segment: string) =>
+  segment.includes('[') ? segment : camelizeString(segment)
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value)
@@ -47,9 +60,11 @@ export class RestClientValidationError extends RestClientError {
    * is not that shape, leaving the caller to fall back.
    *
    * The bodies nest: a field maps either to its messages or to its own fields,
-   * so `{"size": {"non_field_errors": [...]}}` is a complaint about `size`.
-   * Paths are flattened with dots, dropping `non_field_errors` segments because
-   * they name the level above rather than a field of it.
+   * so `{"size": {"non_field_errors": [...]}}` is a complaint about `size`
+   * itself. Those segments are dropped, since they name the level above rather
+   * than a field of it, which leaves `nonFieldErrors` only ever at the root.
+   * Anything deeper is flattened to a dotted path, and every segment is
+   * camelized except one naming the caller's own metadata.
    */
   static parse(json: unknown): ServerValidationErrorResponse | undefined {
     const errors: ServerValidationErrorResponse = {}
@@ -59,7 +74,8 @@ export class RestClientValidationError extends RestClientError {
         return false
       }
       for (const [key, value] of Object.entries(node)) {
-        const nextPath = key === NON_FIELD_ERRORS ? path : [...path, key]
+        const nextPath =
+          key === SERVER_NON_FIELD_ERRORS ? path : [...path, toFieldName(key)]
         if (isStringArray(value)) {
           const field = nextPath.join('.') || NON_FIELD_ERRORS
           errors[field] = [...(errors[field] ?? []), ...value]

--- a/packages/rest-client/src/tools/RestClientValidationError.ts
+++ b/packages/rest-client/src/tools/RestClientValidationError.ts
@@ -42,7 +42,6 @@ const formatErrors = (errors: ServerValidationErrorResponse) =>
  * that want to react per field instead of reading the message.
  *
  * @example
- *   ;```ts
  *   try {
  *     await searchFiles({ query: 'abc' }, { authSchema })
  *   } catch (error) {
@@ -50,7 +49,6 @@ const formatErrors = (errors: ServerValidationErrorResponse) =>
  *       error.errors // { query: ['Must be at least 4 characters.'] }
  *     }
  *   }
- *   ```
  */
 export class RestClientValidationError extends RestClientError {
   readonly errors: ServerValidationErrorResponse
@@ -65,6 +63,10 @@ export class RestClientValidationError extends RestClientError {
    * than a field of it, which leaves `nonFieldErrors` only ever at the root.
    * Anything deeper is flattened to a dotted path, and every segment is
    * camelized except one naming the caller's own metadata.
+   *
+   * @param json - A parsed response body.
+   * @returns Errors keyed by field, or `undefined` when the body is shaped some
+   *   other way.
    */
   static parse(json: unknown): ServerValidationErrorResponse | undefined {
     const errors: ServerValidationErrorResponse = {}
@@ -93,6 +95,11 @@ export class RestClientValidationError extends RestClientError {
       : undefined
   }
 
+  /**
+   * @param errors - Errors keyed by field, as {@link parse} returns them. The
+   *   message is derived from them, so the two cannot disagree.
+   * @param options - The request and response that produced them.
+   */
   constructor(
     errors: ServerValidationErrorResponse,
     options: RestClientErrorOptions = {}
@@ -110,13 +117,15 @@ export class RestClientValidationError extends RestClientError {
  * Narrows a caught value, which TypeScript types as `unknown`, without a cast.
  *
  * @example
- *   ;```ts
  *   catch (error) {
- *     if (isRestClientValidationError(error)) {
- *       error.errors.query // typed
- *     }
+ *   if (isRestClientValidationError(error)) {
+ *   error.errors.query // typed
  *   }
- *   ```
+ *   }
+ *
+ * @param error - Any caught value.
+ * @returns Whether the server rejected the request's contents, as opposed to
+ *   failing for some other reason.
  */
 export const isRestClientValidationError = (
   error: unknown

--- a/packages/rest-client/src/tools/RestClientValidationError.ts
+++ b/packages/rest-client/src/tools/RestClientValidationError.ts
@@ -1,0 +1,108 @@
+import { RestClientError, RestClientErrorOptions } from './RestClientError'
+import { ServerValidationErrorResponse } from '../types/ServerErrorResponse'
+
+/** Errors that belong to a level rather than to one of its fields. */
+const NON_FIELD_ERRORS = 'non_field_errors'
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+const formatErrors = (errors: ServerValidationErrorResponse) =>
+  Object.entries(errors)
+    .map(([field, messages]) =>
+      field === NON_FIELD_ERRORS
+        ? messages.join(' ')
+        : `${field}: ${messages.join(', ')}`
+    )
+    .join('; ')
+
+/**
+ * A request rejected for its contents rather than for what it addressed: `POST
+ * /files/search/` answers this way when a condition is malformed or missing.
+ *
+ * It extends {@link RestClientError}, so code that catches that keeps working
+ * and `status`, `request` and `response` are where they always were. What it
+ * adds is {@link errors}: the server's complaints keyed by field, for callers
+ * that want to react per field instead of reading the message.
+ *
+ * @example
+ *   ;```ts
+ *   try {
+ *     await searchFiles({ query: 'abc' }, { authSchema })
+ *   } catch (error) {
+ *     if (error instanceof RestClientValidationError) {
+ *       error.errors // { query: ['Must be at least 4 characters.'] }
+ *     }
+ *   }
+ *   ```
+ */
+export class RestClientValidationError extends RestClientError {
+  readonly errors: ServerValidationErrorResponse
+
+  /**
+   * Reads a response body as validation errors, or returns `undefined` when it
+   * is not that shape, leaving the caller to fall back.
+   *
+   * The bodies nest: a field maps either to its messages or to its own fields,
+   * so `{"size": {"non_field_errors": [...]}}` is a complaint about `size`.
+   * Paths are flattened with dots, dropping `non_field_errors` segments because
+   * they name the level above rather than a field of it.
+   */
+  static parse(json: unknown): ServerValidationErrorResponse | undefined {
+    const errors: ServerValidationErrorResponse = {}
+
+    const collect = (node: unknown, path: string[]): boolean => {
+      if (!isPlainObject(node)) {
+        return false
+      }
+      for (const [key, value] of Object.entries(node)) {
+        const nextPath = key === NON_FIELD_ERRORS ? path : [...path, key]
+        if (isStringArray(value)) {
+          const field = nextPath.join('.') || NON_FIELD_ERRORS
+          errors[field] = [...(errors[field] ?? []), ...value]
+          continue
+        }
+        if (!collect(value, nextPath)) {
+          return false
+        }
+      }
+      return true
+    }
+
+    return collect(json, []) && Object.keys(errors).length > 0
+      ? errors
+      : undefined
+  }
+
+  constructor(
+    errors: ServerValidationErrorResponse,
+    options: RestClientErrorOptions = {}
+  ) {
+    super(formatErrors(errors), options)
+
+    this.name = 'RestClientValidationError'
+    this.errors = errors
+
+    Object.setPrototypeOf(this, RestClientValidationError.prototype)
+  }
+}
+
+/**
+ * Narrows a caught value, which TypeScript types as `unknown`, without a cast.
+ *
+ * @example
+ *   ;```ts
+ *   catch (error) {
+ *     if (isRestClientValidationError(error)) {
+ *       error.errors.query // typed
+ *     }
+ *   }
+ *   ```
+ */
+export const isRestClientValidationError = (
+  error: unknown
+): error is RestClientValidationError =>
+  error instanceof RestClientValidationError

--- a/packages/rest-client/src/tools/RestClientValidationError.ts
+++ b/packages/rest-client/src/tools/RestClientValidationError.ts
@@ -20,8 +20,19 @@ const toFieldName = (segment: string) =>
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value)
 
-const isStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) && value.every((item) => typeof item === 'string')
+/**
+ * A field's complaints. Usually an array, but the API sometimes sends a bare
+ * string — `{"is_image": "Must be a boolean value."}` — so both are read and
+ * kept as an array, leaving callers one shape to handle.
+ */
+const toMessages = (value: unknown): string[] | undefined => {
+  if (typeof value === 'string') {
+    return [value]
+  }
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : undefined
+}
 
 const formatErrors = (errors: ServerValidationErrorResponse) =>
   Object.entries(errors)
@@ -78,9 +89,10 @@ export class RestClientValidationError extends RestClientError {
       for (const [key, value] of Object.entries(node)) {
         const nextPath =
           key === SERVER_NON_FIELD_ERRORS ? path : [...path, toFieldName(key)]
-        if (isStringArray(value)) {
+        const messages = toMessages(value)
+        if (messages) {
           const field = nextPath.join('.') || NON_FIELD_ERRORS
-          errors[field] = [...(errors[field] ?? []), ...value]
+          errors[field] = [...(errors[field] ?? []), ...messages]
           continue
         }
         if (!collect(value, nextPath)) {

--- a/packages/rest-client/src/types/ServerErrorResponse.ts
+++ b/packages/rest-client/src/types/ServerErrorResponse.ts
@@ -1,3 +1,9 @@
 export type ServerErrorResponse = {
   detail: string
 }
+
+/**
+ * Validation errors keyed by the field they belong to, as `POST /files/search/`
+ * returns for a 400. There is no `detail` in this shape.
+ */
+export type ServerValidationErrorResponse = Record<string, string[]>

--- a/packages/rest-client/src/types/ServerErrorResponse.ts
+++ b/packages/rest-client/src/types/ServerErrorResponse.ts
@@ -1,3 +1,4 @@
+/** How most endpoints report a failure: one human-readable sentence. */
 export type ServerErrorResponse = {
   detail: string
 }

--- a/packages/upload-client/src/index.ts
+++ b/packages/upload-client/src/index.ts
@@ -80,6 +80,7 @@ export {
   CancelError,
   UploadcareError,
   camelizeKeys,
+  Camelize,
   camelizeString,
   SnakeCasedPropertiesDeep,
   poll,


### PR DESCRIPTION
Adds `searchFiles` for `POST /files/search/`, completing the REST 0.7 tags work: the package could already read and write tags but had no way to search by them.

## The API

```ts
const page = await searchFiles(
  {
    tags: { all: ['cat', 'animal'], none: ['draft'] },
    isImage: true,
    sort: [{ field: 'datetimeUploaded', order: 'desc' }, { field: 'size' }],
    limit: 50
  },
  { authSchema }
)

page.total
page.results[0].highlight?.originalFilename // ['n04228054_ski.<em>JPEG</em>']
```

Every documented condition is covered: `query`, `phrase`, `exact`, `datetimeUploaded` and `size` ranges, `isImage`, `tags` (any/all/none), `fuzziness`, `sort`, plus `limit`/`offset`/`include=appdata` as query params.

**One casing rule, applied throughout: the client speaks camelCase, and only data you own keeps the spelling you gave it.** Options and filter field names are camelCase and the mapper translates them (`detectedMimeType` → `detected_mime_type`, `{ field: 'datetimeUploaded', order: 'desc' }` → `-datetime_uploaded`). Your metadata keys and tag values pass through verbatim — on the way out as `metadata[your_key]`, on the way back inside `highlight.metadata`, and in error field names.

Two things worth a reviewer's attention:

- **`exact.metadata` is nested.** The API addresses one metadata key with a literal `metadata[key]` key of `exact` itself, so you write `metadata: { color: ['red'] }` and the mapper produces `"metadata[color]": ["red"]`. You never assemble a wire-format string.
- **The API's own rules are not encoded in types** (at least one condition, 1–4 sort keys, no `phrase`/`exact` overlap). An `AtLeastOne<T>` union makes every unrelated type error in the options unreadable, and the 400s are now legible — see below.

## Shared change: a validation error class

Search rejects a bad query with errors keyed by field and **no `detail`**. `handleApiRequest` read `.detail`, so those details were dropped and the message degraded to a bare `[400] Bad Request`.

The docs describe that body as field names mapped to arrays of error strings. CI proved otherwise, so I captured the real thing — it nests one level deeper:

```json
{"non_field_errors":["At least one search criterion must be specified."]}
{"size":{"non_field_errors":["Invalid data. Expected a dictionary, but got int."]}}
```

`RestClientValidationError` owns reading and formatting it. `parse` drops the nested `non_field_errors` segments, since they name the level above rather than a field of it, which leaves `nonFieldErrors` only ever at the root and turns that second body into `{ size: [...] }`. Field names are camelized, except a segment naming your metadata: `camelizeString('metadata[color]')` returns `metadataColor` and would lose both the key and the bracket form.

```ts
catch (error) {
  if (isRestClientValidationError(error)) {
    error.message // '[400 Bad Request] query: Must be at least 4 characters.'
    error.errors  // { query: ['Must be at least 4 characters.'] }
  }
}
```

It extends `RestClientError`, so existing `catch` blocks and `instanceof` checks keep working and `status`/`request`/`response` are inherited. `isRestClientError` and `isRestClientValidationError` narrow a caught `unknown` without a cast.

**Behavioral change on a shared path, worth a deliberate look.** For any endpoint whose non-2xx body is field-keyed rather than `detail`-keyed, two things change: `error.message` gains the field detail instead of reading `[400] Bad Request`, and `error.name` becomes `RestClientValidationError`. Code that catches or checks `instanceof` is unaffected; code matching on message text or comparing `.name === 'RestClientError'` is not. Search is the endpoint I've confirmed sends such bodies; I can't rule out others. I'd call it a fix — the old path threw away information the server was already sending — but it isn't invisible. Bodies carrying `detail` produce byte-identical messages to before.

## Pagination

`searchFiles` returns `PaginatedList`, and its `limit`/`offset` options match the query params `Paginator` reads off the `next` URL, so `paginate(searchFiles)` and `Paginator` work without new code. The README's "only two paginatable methods" line now says three and documents the API's `offset + limit < 1000` ceiling, which caps any walk over search results.

## Testing

The request body is where this feature can silently go wrong, and this package's API-method tests hit the live API asserting response shape — so nothing there would catch `detectedMimeType` failing to become `detected_mime_type`. The mapping therefore lives in `toSearchBody`, a pure function, tested directly with no network and without adding a mocking dependency.

- `toSearchBody.test.ts` — 13 tests: every condition's key mapping, `metadata[key]` flattening, metadata keys left verbatim, `Date` → ISO, sort tokens in order, `undefined` omitted rather than sent as `null`, and `limit`/`offset`/`include` never entering the body
- `handleApiRequest.test.ts` — new: `detail` bodies keep their exact previous message and throw a plain `RestClientError`; the two bodies captured from the live API are pinned verbatim; field names camelize while `metadata[my_key]` survives; a body of neither shape still degrades to the status
- `searchFiles.test.ts` — 8 live tests asserting shape rather than which files come back, since search indexes asynchronously and the test project's contents aren't fixed

All 8 live tests pass against the real API, and the round trip was verified with real data rather than only assertions: `highlight` arrives as `{"originalFilename":["n04228054_ski.<em>JPEG</em>"]}`, and a short query rejects with `errors: {"query":["Must be at least 4 characters."]}`.

No release: the changelog generates from these commit messages, and `npm run release:prepare` is yours to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
