### PR TITLE
refactor(api-client-utils): loop-based poll, plus camelizeKeys and poll exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6678,7 +6678,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.1",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -15580,7 +15582,10 @@
     "packages/api-client-utils": {
       "name": "@uploadcare/api-client-utils",
       "version": "6.19.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "expect-type": "^1.4.0"
+      }
     },
     "packages/cname-prefix": {
       "name": "@uploadcare/cname-prefix",

--- a/packages/api-client-utils/package.json
+++ b/packages/api-client-utils/package.json
@@ -32,5 +32,8 @@
   "bugs": {
     "url": "https://github.com/uploadcare/uploadcare-js-api-clients/issues"
   },
-  "homepage": "https://github.com/uploadcare/uploadcare-js-api-clients#readme"
+  "homepage": "https://github.com/uploadcare/uploadcare-js-api-clients#readme",
+  "devDependencies": {
+    "expect-type": "^1.4.0"
+  }
 }

--- a/packages/api-client-utils/src/camelizeKeys.test.ts
+++ b/packages/api-client-utils/src/camelizeKeys.test.ts
@@ -1,4 +1,41 @@
-import { camelizeKeys, camelizeString } from './camelizeKeys'
+import {
+  camelizeKeys,
+  camelizeString,
+  SnakeCasedPropertiesDeep
+} from './camelizeKeys'
+
+describe('SnakeCasedPropertiesDeep', () => {
+  it('should rewrite nested keys and keep collection shapes', () => {
+    type Source = {
+      isReady: boolean
+      imageInfo: { colorMode: string; dpi: readonly [number, number] }
+      contentInfo: { videoInfo: { audioTracks: { sampleRate: number }[] } }
+    }
+
+    type Expected = {
+      is_ready: boolean
+      image_info: { color_mode: string; dpi: readonly [number, number] }
+      content_info: { video_info: { audio_tracks: { sample_rate: number }[] } }
+    }
+
+    const raw: SnakeCasedPropertiesDeep<Source> = {
+      is_ready: true,
+      image_info: { color_mode: 'RGB', dpi: [72, 72] },
+      content_info: { video_info: { audio_tracks: [{ sample_rate: 44100 }] } }
+    }
+    // Assignable both ways, so widening the tuple to number[] or dropping its
+    // readonly would fail to compile rather than pass silently.
+    const asExpected: Expected = raw
+    const fromExpected: SnakeCasedPropertiesDeep<Source> = asExpected
+    void fromExpected
+
+    expect(camelizeKeys<Source>(raw)).toEqual({
+      isReady: true,
+      imageInfo: { colorMode: 'RGB', dpi: [72, 72] },
+      contentInfo: { videoInfo: { audioTracks: [{ sampleRate: 44100 }] } }
+    })
+  })
+})
 
 describe('camelizeString', () => {
   it('should work', () => {

--- a/packages/api-client-utils/src/camelizeKeys.test.ts
+++ b/packages/api-client-utils/src/camelizeKeys.test.ts
@@ -1,39 +1,84 @@
+import { expectTypeOf } from 'expect-type'
 import {
   camelizeKeys,
   camelizeString,
   SnakeCasedPropertiesDeep
 } from './camelizeKeys'
 
+type Source = {
+  isReady: boolean
+  imageInfo: { colorMode: string; dpi: readonly [number, number] }
+  contentInfo: { videoInfo: { audioTracks: { sampleRate: number }[] } }
+}
+
+type Raw = {
+  is_ready: boolean
+  image_info: { color_mode: string; dpi: readonly [number, number] }
+  content_info: { video_info: { audio_tracks: { sample_rate: number }[] } }
+}
+
 describe('SnakeCasedPropertiesDeep', () => {
-  it('should rewrite nested keys and keep collection shapes', () => {
-    type Source = {
-      isReady: boolean
-      imageInfo: { colorMode: string; dpi: readonly [number, number] }
-      contentInfo: { videoInfo: { audioTracks: { sampleRate: number }[] } }
-    }
+  it('should rewrite keys at every level', () => {
+    expectTypeOf<SnakeCasedPropertiesDeep<Source>>().toEqualTypeOf<Raw>()
+  })
 
-    type Expected = {
-      is_ready: boolean
-      image_info: { color_mode: string; dpi: readonly [number, number] }
-      content_info: { video_info: { audio_tracks: { sample_rate: number }[] } }
-    }
+  it('should rewrite keys, not values', () => {
+    expectTypeOf<
+      SnakeCasedPropertiesDeep<{ mimeType: string }>
+    >().toEqualTypeOf<{ mime_type: string }>()
+    expectTypeOf<SnakeCasedPropertiesDeep<{ isImage: boolean }>>()
+      .toHaveProperty('is_image')
+      .toBeBoolean()
+  })
 
-    const raw: SnakeCasedPropertiesDeep<Source> = {
-      is_ready: true,
-      image_info: { color_mode: 'RGB', dpi: [72, 72] },
-      content_info: { video_info: { audio_tracks: [{ sample_rate: 44100 }] } }
-    }
-    // Assignable both ways, so widening the tuple to number[] or dropping its
-    // readonly would fail to compile rather than pass silently.
-    const asExpected: Expected = raw
-    const fromExpected: SnakeCasedPropertiesDeep<Source> = asExpected
-    void fromExpected
+  it('should keep digits attached rather than splitting them off', () => {
+    expectTypeOf<
+      SnakeCasedPropertiesDeep<{ s3Bucket: string }>
+    >().toEqualTypeOf<{
+      s3_bucket: string
+    }>()
+  })
 
-    expect(camelizeKeys<Source>(raw)).toEqual({
-      isReady: true,
-      imageInfo: { colorMode: 'RGB', dpi: [72, 72] },
-      contentInfo: { videoInfo: { audioTracks: [{ sampleRate: 44100 }] } }
-    })
+  it('should keep tuple shape and readonly-ness', () => {
+    expectTypeOf<
+      SnakeCasedPropertiesDeep<{ dpi: readonly [number, number] }>['dpi']
+    >().toEqualTypeOf<readonly [number, number]>()
+    // A homomorphic mapped type is what preserves these: the previous
+    // `SnakeCasedPropertiesDeep<U>[]` branch collapsed both to `number[]`.
+    expectTypeOf<
+      SnakeCasedPropertiesDeep<{ dpi: readonly [number, number] }>['dpi']
+    >().not.toEqualTypeOf<number[]>()
+  })
+
+  it('should rewrite the element type of arrays of objects', () => {
+    expectTypeOf<
+      SnakeCasedPropertiesDeep<{ videoInfo: { bitRate: number } }[]>
+    >().toEqualTypeOf<{ video_info: { bit_rate: number } }[]>()
+  })
+
+  it('should pass primitives and null through untouched', () => {
+    expectTypeOf<SnakeCasedPropertiesDeep<string>>().toEqualTypeOf<string>()
+    expectTypeOf<SnakeCasedPropertiesDeep<number>>().toEqualTypeOf<number>()
+    expectTypeOf<SnakeCasedPropertiesDeep<null>>().toEqualTypeOf<null>()
+  })
+})
+
+describe('camelizeKeys types', () => {
+  it('should return the type the caller asks for', () => {
+    expectTypeOf(camelizeKeys<Source>({} as Raw)).toEqualTypeOf<Source>()
+  })
+
+  it('should default to a plain record so untyped calls keep compiling', () => {
+    expectTypeOf(camelizeKeys({ a_b: 1 })).toEqualTypeOf<
+      Record<string, unknown>
+    >()
+  })
+
+  it('should accept any input, since a raw frame is not typed yet', () => {
+    expectTypeOf(camelizeKeys).parameter(0).toBeUnknown()
+    expectTypeOf(camelizeKeys<Source>)
+      .parameter(1)
+      .toEqualTypeOf<{ ignoreKeys: string[] } | undefined>()
   })
 })
 

--- a/packages/api-client-utils/src/camelizeKeys.ts
+++ b/packages/api-client-utils/src/camelizeKeys.ts
@@ -13,6 +13,29 @@ export function camelizeString<T extends string>(text: T): T {
     .join('') as T
 }
 
+type SnakeCase<S extends string> = S extends `${infer Head}${infer Tail}`
+  ? Head extends Uppercase<Head>
+    ? Head extends Lowercase<Head>
+      ? `${Head}${SnakeCase<Tail>}` // digit or other non-letter — kept as-is
+      : `_${Lowercase<Head>}${SnakeCase<Tail>}` // uppercase letter — prefix an underscore
+    : `${Head}${SnakeCase<Tail>}` // lowercase letter
+  : S
+
+/**
+ * Type-level inverse of {@link camelizeKeys}: recursively rewrite an object's
+ * camelCase keys to snake_case. Lets a raw API frame be described as the
+ * snake_case form of a camelCase type such as `FileInfo`.
+ */
+export type SnakeCasedPropertiesDeep<T> = T extends readonly (infer U)[]
+  ? SnakeCasedPropertiesDeep<U>[]
+  : T extends object
+    ? {
+        [K in keyof T as K extends string
+          ? SnakeCase<K>
+          : K]: SnakeCasedPropertiesDeep<T[K]>
+      }
+    : T
+
 type CamelizeKeysOptions = {
   ignoreKeys: string[]
 }

--- a/packages/api-client-utils/src/camelizeKeys.ts
+++ b/packages/api-client-utils/src/camelizeKeys.ts
@@ -50,15 +50,22 @@ export function camelizeArrayItems(
   return array.map((item) => camelizeKeys(item, { ignoreKeys }))
 }
 
-export function camelizeKeys<T>(
-  source: Record<string, unknown> | T,
+/**
+ * Recursively rewrite an object's snake_case keys to camelCase.
+ *
+ * The result is whatever the caller says it is: pass the camelCase type it
+ * produces (`camelizeKeys<FileInfo>(raw)`) instead of casting the return value.
+ * Non-objects pass through untouched.
+ */
+export function camelizeKeys<T = unknown>(
+  source: unknown,
   { ignoreKeys }: CamelizeKeysOptions = { ignoreKeys: [] }
-): Record<string, unknown> | T {
+): T {
   if (Array.isArray(source)) {
-    return camelizeArrayItems(source, { ignoreKeys }) as unknown as T
+    return camelizeArrayItems(source, { ignoreKeys }) as T
   }
   if (!isObject(source)) {
-    return source
+    return source as T
   }
   const result: Record<string, unknown> = {}
   for (const key of Object.keys(source)) {
@@ -74,5 +81,5 @@ export function camelizeKeys<T>(
     }
     result[camelizeString(key)] = value
   }
-  return result
+  return result as T
 }

--- a/packages/api-client-utils/src/camelizeKeys.ts
+++ b/packages/api-client-utils/src/camelizeKeys.ts
@@ -55,9 +55,10 @@ export function camelizeArrayItems(
  *
  * The result is whatever the caller says it is: pass the camelCase type it
  * produces (`camelizeKeys<FileInfo>(raw)`) instead of casting the return value.
+ * Defaults to a plain record, so existing untyped calls keep compiling.
  * Non-objects pass through untouched.
  */
-export function camelizeKeys<T = unknown>(
+export function camelizeKeys<T = Record<string, unknown>>(
   source: unknown,
   { ignoreKeys }: CamelizeKeysOptions = { ignoreKeys: [] }
 ): T {

--- a/packages/api-client-utils/src/camelizeKeys.ts
+++ b/packages/api-client-utils/src/camelizeKeys.ts
@@ -25,9 +25,12 @@ type SnakeCase<S extends string> = S extends `${infer Head}${infer Tail}`
  * Type-level inverse of {@link camelizeKeys}: recursively rewrite an object's
  * camelCase keys to snake_case. Lets a raw API frame be described as the
  * snake_case form of a camelCase type such as `FileInfo`.
+ *
+ * Arrays and tuples keep their own shape — length, labels and `readonly` — and
+ * only their element types are rewritten.
  */
-export type SnakeCasedPropertiesDeep<T> = T extends readonly (infer U)[]
-  ? SnakeCasedPropertiesDeep<U>[]
+export type SnakeCasedPropertiesDeep<T> = T extends readonly unknown[]
+  ? { [K in keyof T]: SnakeCasedPropertiesDeep<T[K]> }
   : T extends object
     ? {
         [K in keyof T as K extends string

--- a/packages/api-client-utils/src/delay.test.ts
+++ b/packages/api-client-utils/src/delay.test.ts
@@ -7,4 +7,24 @@ describe('delay', () => {
     const end = Date.now()
     expect(end - start).toBeGreaterThan(100 - 10)
   })
+
+  it('should resolve early when the signal aborts', async () => {
+    const ctrl = new AbortController()
+    setTimeout(() => ctrl.abort(), 20)
+
+    const start = Date.now()
+    await delay(1000, ctrl.signal)
+
+    expect(Date.now() - start).toBeLessThan(500)
+  })
+
+  it('should resolve immediately when the signal is already aborted', async () => {
+    const ctrl = new AbortController()
+    ctrl.abort()
+
+    const start = Date.now()
+    await delay(1000, ctrl.signal)
+
+    expect(Date.now() - start).toBeLessThan(100)
+  })
 })

--- a/packages/api-client-utils/src/delay.ts
+++ b/packages/api-client-utils/src/delay.ts
@@ -2,6 +2,20 @@
  * SetTimeout as Promise.
  *
  * @param {number} ms Timeout in milliseconds.
+ * @param {AbortSignal} [signal] Resolves the promise early when aborted, so a
+ *   caller waiting on it can react to the abort right away.
  */
-export const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms))
+export const delay = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const done = (): void => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', done)
+      resolve()
+    }
+    const timer = setTimeout(done, ms)
+    signal?.addEventListener('abort', done, { once: true })
+  })

--- a/packages/api-client-utils/src/index.ts
+++ b/packages/api-client-utils/src/index.ts
@@ -1,4 +1,8 @@
-export { camelizeKeys, camelizeString } from './camelizeKeys'
+export {
+  camelizeKeys,
+  camelizeString,
+  SnakeCasedPropertiesDeep
+} from './camelizeKeys'
 export { delay } from './delay'
 export {
   getUserAgent,

--- a/packages/api-client-utils/src/poll.test.ts
+++ b/packages/api-client-utils/src/poll.test.ts
@@ -182,6 +182,21 @@ describe('poll', () => {
     expect(Date.now() - start).toBeLessThan(500)
   })
 
+  it('should reject rather than resolve with a result that lands after cancel', async () => {
+    const ctrl = new AbortController()
+    // Ignores the signal and succeeds right after the abort.
+    const check: PollCheckFunction<string> = async () => {
+      await delay(30)
+      return 'done'
+    }
+
+    setTimeout(() => ctrl.abort(), 10)
+
+    await expect(
+      poll({ check, interval: 10, signal: ctrl.signal })
+    ).rejects.toThrowError(new CancelError('Poll cancelled'))
+  })
+
   it('should handle errors', async () => {
     const error = new Error('test error')
     const job = longJob(3, error)

--- a/packages/api-client-utils/src/poll.test.ts
+++ b/packages/api-client-utils/src/poll.test.ts
@@ -148,6 +148,40 @@ describe('poll', () => {
     expect(job.spy.condition).toHaveBeenCalledTimes(conditionCallsCount)
   })
 
+  it('should stop polling when cancelled while a check is in flight', async () => {
+    const ctrl = new AbortController()
+    let runs = 0
+    const check: PollCheckFunction<boolean> = async () => {
+      runs += 1
+      await delay(30)
+      return false
+    }
+
+    setTimeout(() => ctrl.abort(), 10)
+
+    await expect(
+      poll({ check, interval: 10, signal: ctrl.signal })
+    ).rejects.toThrowError(new CancelError('Poll cancelled'))
+
+    const runsAtCancel = runs
+    await delay(60)
+    expect(runs).toBe(runsAtCancel)
+  })
+
+  it('should reject as soon as the signal aborts mid-interval', async () => {
+    const ctrl = new AbortController()
+    const job = longJob(100)
+
+    setTimeout(() => ctrl.abort(), 20)
+    const start = Date.now()
+
+    await expect(
+      poll({ check: job.isFinish, interval: 1000, signal: ctrl.signal })
+    ).rejects.toThrowError(new CancelError('Poll cancelled'))
+
+    expect(Date.now() - start).toBeLessThan(500)
+  })
+
   it('should handle errors', async () => {
     const error = new Error('test error')
     const job = longJob(3, error)

--- a/packages/api-client-utils/src/poll.ts
+++ b/packages/api-client-utils/src/poll.ts
@@ -12,8 +12,11 @@ const DEFAULT_INTERVAL = 500
  * milliseconds between attempts, and resolve with that value.
  *
  * Rejects with a `CancelError` when `signal` aborts or `timeout` elapses,
- * whichever happens first. Either one stops the loop for good: no further
- * `check` call is made, and a call already in flight is abandoned.
+ * whichever happens first. Either one ends the loop for good: no further
+ * `check` runs, and the result of one already in flight is discarded.
+ *
+ * A `check` in flight is still awaited before that rejection surfaces, so pass
+ * `signal` on to whatever the attempt does if cancellation should be prompt.
  *
  * @param check Runs one attempt; anything falsy means "not done yet". Receives
  *   `signal` so the attempt itself can be aborted.
@@ -50,6 +53,10 @@ const poll = async <T>({
     } catch (error) {
       // A rejection caused by our own abort is a cancellation, not a failure.
       throw signal?.aborted ? new CancelError('Poll cancelled') : error
+    }
+    // Cancellation wins over a result that landed while it was in flight.
+    if (signal?.aborted) {
+      throw new CancelError('Poll cancelled')
     }
     if (result) {
       return result

--- a/packages/api-client-utils/src/poll.ts
+++ b/packages/api-client-utils/src/poll.ts
@@ -1,5 +1,5 @@
-import { onCancel } from './onCancel'
 import { CancelError } from './CancelError'
+import { delay } from './delay'
 
 type PollCheckFunction<T> = (
   signal?: AbortSignal
@@ -7,7 +7,21 @@ type PollCheckFunction<T> = (
 
 const DEFAULT_INTERVAL = 500
 
-const poll = <T>({
+/**
+ * Call `check` until it returns something truthy, waiting `interval`
+ * milliseconds between attempts, and resolve with that value.
+ *
+ * Rejects with a `CancelError` when `signal` aborts or `timeout` elapses,
+ * whichever happens first. Either one stops the loop for good: no further
+ * `check` call is made, and a call already in flight is abandoned.
+ *
+ * @param check Runs one attempt; anything falsy means "not done yet". Receives
+ *   `signal` so the attempt itself can be aborted.
+ * @param interval Milliseconds between attempts. Defaults to 500.
+ * @param timeout Milliseconds to keep trying for. Unbounded when omitted.
+ * @param signal Aborts the polling.
+ */
+const poll = async <T>({
   check,
   interval = DEFAULT_INTERVAL,
   timeout,
@@ -17,45 +31,33 @@ const poll = <T>({
   timeout?: number
   interval?: number
   signal?: AbortSignal
-}): Promise<T> =>
-  new Promise((resolve, reject) => {
-    let tickTimeoutId: NodeJS.Timeout
-    let timeoutId: NodeJS.Timeout
+}): Promise<T> => {
+  const startedAt = Date.now()
+  const timeLeft = (): number =>
+    timeout === undefined ? Infinity : timeout - (Date.now() - startedAt)
 
-    onCancel(signal, () => {
-      tickTimeoutId && clearTimeout(tickTimeoutId)
-      reject(new CancelError('Poll cancelled'))
-    })
-
-    if (timeout) {
-      timeoutId = setTimeout(() => {
-        tickTimeoutId && clearTimeout(tickTimeoutId)
-        reject(new CancelError('Timed out'))
-      }, timeout)
+  for (;;) {
+    if (signal?.aborted) {
+      throw new CancelError('Poll cancelled')
+    }
+    if (timeLeft() <= 0) {
+      throw new CancelError('Timed out')
     }
 
-    const tick = (): void => {
-      try {
-        Promise.resolve(check(signal))
-          .then((result) => {
-            if (result) {
-              timeoutId && clearTimeout(timeoutId)
-              resolve(result)
-            } else {
-              tickTimeoutId = setTimeout(tick, interval)
-            }
-          })
-          .catch((error) => {
-            timeoutId && clearTimeout(timeoutId)
-            reject(error)
-          })
-      } catch (error) {
-        timeoutId && clearTimeout(timeoutId)
-        reject(error)
-      }
+    let result: false | T
+    try {
+      result = await check(signal)
+    } catch (error) {
+      // A rejection caused by our own abort is a cancellation, not a failure.
+      throw signal?.aborted ? new CancelError('Poll cancelled') : error
+    }
+    if (result) {
+      return result
     }
 
-    tickTimeoutId = setTimeout(tick, 0)
-  })
+    // Never sleep past the deadline, so the timeout is reported on time.
+    await delay(Math.min(interval, timeLeft()), signal)
+  }
+}
 
 export { poll, PollCheckFunction }

--- a/packages/rest-client/src/api/handleApiRequest.ts
+++ b/packages/rest-client/src/api/handleApiRequest.ts
@@ -43,7 +43,7 @@ export async function handleApiRequest<ResponseType>(
     return json as ResponseType
   }
 
-  return camelizeKeys(json, {
+  return camelizeKeys<ResponseType>(json, {
     ignoreKeys: CAMELIZE_IGNORE_KEYS
-  }) as ResponseType
+  })
 }

--- a/packages/upload-client/src/api/base.ts
+++ b/packages/upload-client/src/api/base.ts
@@ -102,7 +102,7 @@ export default function base(
         signal,
         onProgress
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
         if ('error' in response) {
           throw new UploadError(
             response.error.content,

--- a/packages/upload-client/src/api/fromUrl.ts
+++ b/packages/upload-client/src/api/fromUrl.ts
@@ -120,7 +120,7 @@ export default function fromUrl(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/api/fromUrlStatus.ts
+++ b/packages/upload-client/src/api/fromUrlStatus.ts
@@ -105,7 +105,7 @@ export default function fromUrlStatus(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response && !isErrorResponse(response)) {
           throw new UploadError(

--- a/packages/upload-client/src/api/group.ts
+++ b/packages/upload-client/src/api/group.ts
@@ -68,7 +68,7 @@ export default function group(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/api/groupInfo.ts
+++ b/packages/upload-client/src/api/groupInfo.ts
@@ -55,7 +55,7 @@ export default function groupInfo(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/api/info.ts
+++ b/packages/upload-client/src/api/info.ts
@@ -56,7 +56,7 @@ export default function info(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/api/multipartComplete.ts
+++ b/packages/upload-client/src/api/multipartComplete.ts
@@ -52,7 +52,7 @@ export default function multipartComplete(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/api/multipartStart.ts
+++ b/packages/upload-client/src/api/multipartStart.ts
@@ -96,7 +96,7 @@ export default function multipartStart(
         }),
         signal
       }).then(({ data, headers, request }) => {
-        const response = camelizeKeys(JSON.parse(data)) as Response
+        const response = camelizeKeys<Response>(JSON.parse(data))
 
         if ('error' in response) {
           throw new UploadError(

--- a/packages/upload-client/src/index.ts
+++ b/packages/upload-client/src/index.ts
@@ -78,7 +78,12 @@ export {
   CustomUserAgentOptions,
   GetUserAgentOptions,
   CancelError,
-  UploadcareError
+  UploadcareError,
+  camelizeKeys,
+  camelizeString,
+  SnakeCasedPropertiesDeep,
+  poll,
+  PollCheckFunction
 } from '@uploadcare/api-client-utils'
 export { Queue, Task } from './tools/Queue'
 


### PR DESCRIPTION
## Why

Two things, both about code that already exists in the bundle but isn't usable or clean.

1. **Consumers that talk to the Upload API directly vendor code we already ship.** `camelizeKeys` to turn a snake_case frame into `FileInfo`, `poll` to drive an async job to completion — both present, neither exported.
2. **`poll` doesn't fully stop when told to.** Aborting while a `check` is in flight leaves that call's `.then()` free to schedule the next tick, and the timeout timer is never cleared on abort.

## What

| Commit | Change |
| --- | --- |
| `feat(api-client-utils): let delay resolve early on abort` | `delay(ms, signal?)`, so a waiter reacts to an abort instead of sitting out the timeout |
| `refactor(api-client-utils): express poll as a loop` | async loop in place of the nested-promise/timer chain; closes the two holes above |
| `feat(api-client-utils): add SnakeCasedPropertiesDeep` | type-level inverse of `camelizeKeys` |
| `feat(upload-client): export camelizeKeys, poll and their types` | `camelizeKeys`, `camelizeString`, `SnakeCasedPropertiesDeep`, `poll`, `PollCheckFunction` |
| `refactor(api-client-utils): let camelizeKeys callers name the result type` | `camelizeKeys<T>(source: unknown): T` — deletes 9 `as Response` / `as ResponseType` casts across upload-client and rest-client |
| `fix(api-client-utils): default camelizeKeys to a plain record` | keeps existing unannotated callers compiling |

## Behaviour and trade-offs, stated plainly

- **The runaway-tick fix is latent, not live.** Every `check` in this repo (`info`, `fromUrlStatus`) passes the signal down, so the in-flight request rejects on abort and no extra tick is scheduled. But `PollCheckFunction`'s signal parameter is optional, so a check that ignores it kept polling forever after cancellation. New test covers that shape.
- **The cleared timeout timer matters for long timeouts.** Previously it stayed pending after abort; with a multi-minute timeout that holds a Node event-loop reference open.
- **The timeout is now noticed between checks**, not by a dedicated timer. A `check` that hangs past the deadline delays the `CancelError` until it settles; the old version rejected at the deadline regardless. Sleeps are capped at the remaining time so an idle poll still rejects on schedule. This is the one axis where the new version is worse, and it can be closed by racing each check against the remaining time if reviewers prefer that.
- `camelizeKeys`' return type changes shape. Old: `Record<string, unknown> | T` (a union you had to cast through anyway). New: `T`, defaulting to `Record<string, unknown>` so unannotated calls keep compiling.

## Testing

- `api-client-utils`: 43 tests, including new cases for abort-during-check, prompt rejection on a mid-interval abort, and the abortable `delay`.
- `upload-client`: 213 tests against the mock server.
- `npm run build` across workspaces, `npm run eslint`, `prettier --check` all clean.

## Not in this PR

An earlier revision also made the Pusher socket primary for `fromUrl` status, with HTTP polling as a delayed fallback. That's been dropped from this branch and can be proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)