### PR TITLE
feat(cname-prefix): compute the async prefix on Node via node:crypto WebCrypto

### DIFF
--- a/packages/cname-prefix/README.md
+++ b/packages/cname-prefix/README.md
@@ -60,7 +60,8 @@ recomputing it for every URL.
 | ----------------------------- | -------- | ---------------------------------------------------------- |
 | Browser, Web/Service Worker   | `…Async` | WebCrypto is already there, so nothing is bundled          |
 | Browser, when you can't await | `…Sync`  | works, and carries a SHA-256 with it (about a kilobyte)    |
-| Node.js                       | `…Sync`  | `node:crypto` is native _and_ synchronous                  |
+| Node.js (server code)         | `…Sync`  | `node:crypto` is native _and_ synchronous — no `Promise`   |
+| Node.js (isomorphic code)     | `…Async` | works too: WebCrypto via `node:crypto`, no runtime branch  |
 | React Native                  | `…Sync`  | no WebCrypto in Hermes; the portable build is the only one |
 
 In a browser, prefer the async variant. It calls
@@ -73,18 +74,40 @@ Use the sync variant when a `Promise` would infect the call site, such as a
 config module's top-level export or a synchronous render path. It works in a
 browser and costs you the SHA-256 it carries, about a kilobyte.
 
-On Node, use the sync variant. The `node` export condition, which Node.js,
+On Node, prefer the sync variant. The `node` export condition, which Node.js,
 Vitest and bundlers targeting Node all resolve, swaps in a build backed by
 `node:crypto`, so the portable SHA-256 never reaches a server bundle. Your
-import stays the same. The async variant rejects there with a `TypeError` naming
-the sync one, since bundling a hash is a browser problem that Node does not
-have.
+import stays the same, and the digest is native and synchronous — no `Promise`
+to await.
+
+The async variant works on Node too. Under the same `node` condition it takes
+WebCrypto from `node:crypto` rather than the global scope, and returns the same
+string the sync one does. Reach for it only to keep a single code path across
+browser and server: isomorphic or SSR code that already awaits
+`getPrefixedCdnBaseAsync` no longer has to branch on the runtime, and no
+`createHash` reaches the call path.
 
 On React Native, use the sync variant too. The `react-native` condition resolves
 to the portable build, which is the only one that can run there: Hermes has
 neither `crypto.subtle` nor `node:crypto`. It needs `TextEncoder`, which Hermes
 provides from React Native 0.74 and Expo SDK 51. On anything older, add a
 polyfill.
+
+### Node version compatibility
+
+Both variants run on every Node the package supports (`engines: node >=16`),
+and neither needs a flag:
+
+| API      | Backed by                  | Available since |
+| -------- | -------------------------- | --------------- |
+| `…Sync`  | `node:crypto` `createHash` | Node 0.x        |
+| `…Async` | `node:crypto` `webcrypto`  | Node 15.0.0     |
+
+The async build reads WebCrypto from `node:crypto` (its `webcrypto` export),
+not from `globalThis.crypto`. So it does not depend on the global `crypto`
+object — which became available by default only in Node 19 — and needs no
+`--experimental-global-webcrypto` flag. On every version this package targets,
+both APIs are present.
 
 ### What it costs
 
@@ -98,8 +121,12 @@ Marginal cost of the helper, esbuild `--minify` over the published build:
 | both, from the root entry, in a browser | 2082 B | 1247 B | **1081 B** |
 
 Brotli is the column to read, since that is what a CDN serves. In a browser the
-async variant costs about a quarter of the sync one. On Node both are small
-enough that the difference rarely matters.
+async variant costs about a quarter of the sync one. On Node the numbers change:
+the digest is `node:crypto`, external to the bundle, so the async variant is a
+few hundred bytes there too — about the same as `/sync` on Node above, not the
+kilobyte the portable sync build costs in a browser. Size is not the deciding
+factor on Node; pick `…Sync` to avoid a `Promise`, `…Async` to share code with
+the browser.
 
 ### Entry points
 

--- a/packages/cname-prefix/package.json
+++ b/packages/cname-prefix/package.json
@@ -44,6 +44,9 @@
     "README.md",
     "LICENSE"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "prepack": "cp ../../LICENSE ./LICENSE",
     "clean": "rimraf dist",

--- a/packages/cname-prefix/src/async/sha256EncodeAsync.ts
+++ b/packages/cname-prefix/src/async/sha256EncodeAsync.ts
@@ -1,20 +1,16 @@
+import { bigintFromSha256Digest } from '../common/bigintFromSha256Digest'
+
 /**
  * SHA-256 of a UTF-8 string, as a 256-bit bigint, via WebCrypto.
  *
  * Reads `crypto` off the global scope rather than off `window`, so this also
- * works inside a Web Worker or a Service Worker, where `window` does not exist.
- * The digest bytes become a bigint through four 64-bit reads — no hex string in
- * between.
+ * works inside a Web Worker or a Service Worker, where `window` does not
+ * exist.
  */
-export const sha256EncodeAsync = async (data: string): Promise<bigint> => {
-  const digest = await globalThis.crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(data)
+export const sha256EncodeAsync = async (data: string): Promise<bigint> =>
+  bigintFromSha256Digest(
+    await globalThis.crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(data)
+    )
   )
-  const view = new DataView(digest)
-  let out = 0n
-  for (let i = 0; i < digest.byteLength; i += 8) {
-    out = (out << 64n) | view.getBigUint64(i)
-  }
-  return out
-}

--- a/packages/cname-prefix/src/common/bigintFromSha256Digest.ts
+++ b/packages/cname-prefix/src/common/bigintFromSha256Digest.ts
@@ -1,0 +1,14 @@
+/**
+ * A SHA-256 digest as a 256-bit bigint, read as four big-endian 64-bit words —
+ * no intermediate hex string. Shared by every WebCrypto-backed encoder, which
+ * differ only in where `crypto.subtle` is reached: the global one in a browser,
+ * `node:crypto`'s `webcrypto` on a server.
+ */
+export const bigintFromSha256Digest = (digest: ArrayBuffer): bigint => {
+  const view = new DataView(digest)
+  let out = 0n
+  for (let i = 0; i < digest.byteLength; i += 8) {
+    out = (out << 64n) | view.getBigUint64(i)
+  }
+  return out
+}

--- a/packages/cname-prefix/src/node/async.test.ts
+++ b/packages/cname-prefix/src/node/async.test.ts
@@ -1,27 +1,54 @@
 import { describe, expect, it } from 'vitest'
 
+import { PUBLIC_KEY_PREFIXES } from '../common/publicKeys.fixture'
 import { getPrefixedCdnBaseAsync } from './async'
+import { getPrefixedCdnBaseSync } from './sync'
+
+const PREFIX_CDN_BASE = 'https://ucarecd.net'
 
 /**
- * The async API is the browser's: it exists because WebCrypto is the only
- * digest a browser offers without shipping an implementation. In Node the sync
- * API is already native, so reaching for the async one means a caller has the
- * environments mixed up — say so, instead of failing later with a
- * `ReferenceError` about `window`.
+ * The async API used to reject in Node; it now computes the prefix through
+ * `node:crypto`'s WebCrypto, so it must land on exactly what the other builds
+ * produce. The prefix is read back off the built base rather than from an
+ * internal, so these assertions run through what the `node` condition actually
+ * publishes.
  */
-describe('node build: the async API is not available', () => {
-  it('rejects with an explanation naming the sync alternative', async () => {
-    await expect(
-      getPrefixedCdnBaseAsync('demopublickey', 'https://ucarecd.net')
-    ).rejects.toThrow(/getPrefixedCdnBaseSync/)
+const prefixOf = async (publicKey: string): Promise<string> =>
+  new URL(
+    await getPrefixedCdnBaseAsync(publicKey, PREFIX_CDN_BASE)
+  ).hostname.split('.')[0] as string
+
+describe('node build: the async prefix', () => {
+  it.each(PUBLIC_KEY_PREFIXES)(
+    'is the one the other builds produce for %s',
+    async (publicKey, prefix) => {
+      expect(await prefixOf(publicKey)).toBe(prefix)
+    }
+  )
+
+  it('agrees with the native sync build for the same public key', async () => {
+    expect(
+      await getPrefixedCdnBaseAsync('demopublickey', PREFIX_CDN_BASE)
+    ).toBe(getPrefixedCdnBaseSync('demopublickey', PREFIX_CDN_BASE))
+  })
+})
+
+describe('node build: getPrefixedCdnBaseAsync', () => {
+  it('prefixes the zone with the project subdomain', async () => {
+    expect(
+      await getPrefixedCdnBaseAsync('demopublickey', PREFIX_CDN_BASE)
+    ).toBe('https://1s4oyld5dc.ucarecd.net')
   })
 
-  it('rejects rather than throwing synchronously, so callers can catch it', async () => {
-    const promise = getPrefixedCdnBaseAsync(
-      'demopublickey',
-      'https://ucarecd.net'
-    )
-    expect(promise).toBeInstanceOf(Promise)
-    await expect(promise).rejects.toThrow(TypeError)
+  it('tolerates a trailing slash and never leaves one behind', async () => {
+    expect(
+      await getPrefixedCdnBaseAsync('demopublickey', `${PREFIX_CDN_BASE}/`)
+    ).toBe('https://1s4oyld5dc.ucarecd.net')
+  })
+
+  it('prefixes a custom host as given', async () => {
+    expect(
+      await getPrefixedCdnBaseAsync('demopublickey', 'https://cdn.example.com')
+    ).toBe('https://1s4oyld5dc.cdn.example.com')
   })
 })

--- a/packages/cname-prefix/src/node/async.ts
+++ b/packages/cname-prefix/src/node/async.ts
@@ -1,23 +1,23 @@
-/**
- * Not available in Node. Present so that a caller who imports it gets an
- * explanation instead of a `ReferenceError` about `window`: the async API
- * exists because WebCrypto is the only digest a browser offers without shipping
- * an implementation, and Node does not have that problem.
- *
- * It rejects rather than throwing synchronously, so the failure arrives where a
- * caller of an async function is already looking for it.
- */
-export const getPrefixedCdnBaseAsync = (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- signature parity with the browser build
-  publicKey: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- signature parity with the browser build
-  cdnBase: string
-): Promise<string> =>
-  Promise.reject(
-    new TypeError(
-      'getPrefixedCdnBaseAsync is available in browsers only, where WebCrypto is the only digest available without bundling one. ' +
-        'In Node the synchronous API is already native — use getPrefixedCdnBaseSync.'
-    )
-  )
+import { addPrefixToCdnBase } from '../common/addPrefixToCdnBase'
+import { cnamePrefix } from '../common/cnamePrefix'
+import { sha256EncodeAsync } from './sha256EncodeAsync'
 
 export { isPrefixedCdnBase } from '../common/isPrefixedCdnBase'
+
+/**
+ * The prefixed CDN base, derived with the same WebCrypto digest the browser
+ * build uses — here taken from `node:crypto`'s `webcrypto`. Node has had
+ * WebCrypto since 16.15, so isomorphic code that calls the async API (an SSR
+ * render, a shared config module) no longer has to branch on the runtime: it
+ * gets the same answer the sync API would, without a `node:crypto` `createHash`
+ * on the call path.
+ *
+ * The result is identical to `getPrefixedCdnBaseSync` for a given public key;
+ * on Node the sync one is native and synchronous, so prefer it where you can
+ * and reach for this only to keep one code path across environments.
+ */
+export const getPrefixedCdnBaseAsync = async (
+  publicKey: string,
+  cdnBase: string
+): Promise<string> =>
+  addPrefixToCdnBase(cnamePrefix(await sha256EncodeAsync(publicKey)), cdnBase)

--- a/packages/cname-prefix/src/node/sha256EncodeAsync.ts
+++ b/packages/cname-prefix/src/node/sha256EncodeAsync.ts
@@ -1,0 +1,19 @@
+import { webcrypto } from 'node:crypto'
+
+import { bigintFromSha256Digest } from '../common/bigintFromSha256Digest'
+
+/**
+ * SHA-256 of a UTF-8 string, as a 256-bit bigint, via WebCrypto — the same
+ * digest the browser build uses, taken from `node:crypto`'s `webcrypto` rather
+ * than off the global scope. That keeps the async API working on every Node the
+ * package supports (`webcrypto` has been present since Node 16.15, no flag),
+ * not only on the versions where `globalThis.crypto` happens to be exposed.
+ *
+ * `node:crypto` is a runtime import the bundler leaves external, so nothing is
+ * added to the bundle; this file is what the `node` condition of the async
+ * entry resolves to.
+ */
+export const sha256EncodeAsync = async (data: string): Promise<bigint> =>
+  bigintFromSha256Digest(
+    await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(data))
+  )

--- a/packages/cname-prefix/src/node/sha256EncodeAsync.ts
+++ b/packages/cname-prefix/src/node/sha256EncodeAsync.ts
@@ -6,7 +6,7 @@ import { bigintFromSha256Digest } from '../common/bigintFromSha256Digest'
  * SHA-256 of a UTF-8 string, as a 256-bit bigint, via WebCrypto — the same
  * digest the browser build uses, taken from `node:crypto`'s `webcrypto` rather
  * than off the global scope. That keeps the async API working on every Node the
- * package supports (`webcrypto` has been present since Node 16.15, no flag),
+ * package supports (`webcrypto` has been present since Node 15.0.0, no flag),
  * not only on the versions where `globalThis.crypto` happens to be exposed.
  *
  * `node:crypto` is a runtime import the bundler leaves external, so nothing is


### PR DESCRIPTION
## What

Make the `node` build of `getPrefixedCdnBaseAsync` actually compute the prefix using the Web Crypto API instead of rejecting.

Previously the Node async build returned `Promise.reject(new TypeError(…'available in browsers only'…))`. It now derives the SHA-256 with WebCrypto taken from `node:crypto`'s `webcrypto` export and returns the same string as `getPrefixedCdnBaseSync`, so isomorphic / SSR code that awaits the async API runs unchanged on the server.

## Why this WebCrypto source

Reads `webcrypto` from `node:crypto` rather than `globalThis.crypto`:

- `crypto.webcrypto` has existed since **Node 15.0.0**, so this honors the package's `engines: node >=16`.
- No `--experimental-global-webcrypto` flag required.
- Does not depend on the global `crypto` object, which is default-on only from Node 19.
- `node:crypto` is already `external` in `vite.config.js`, so nothing is added to the bundle.

## Changes

- **New** `src/common/bigintFromSha256Digest.ts` — shared digest→bigint reader (four big-endian 64-bit words), used by both WebCrypto-backed encoders.
- `src/async/sha256EncodeAsync.ts` — refactored onto the shared helper (still reads `globalThis.crypto`).
- **New** `src/node/sha256EncodeAsync.ts` — encoder using `node:crypto` `webcrypto`.
- `src/node/async.ts` — computes the prefix (`cnamePrefix` + `addPrefixToCdnBase`) instead of rejecting.
- `src/node/async.test.ts` — rewritten to assert correctness against `PUBLIC_KEY_PREFIXES` and parity with the native sync build (was asserting rejection).
- `README.md` — document that the async API works on Node, add a **Node version compatibility** section, update guidance table and cost prose.

## Verification

- Node suite: **111 passed** (async matches sync + 49 fixtures; export-parity test holds).
- Browser suite: **133 passed** (shared-helper refactor intact).
- `tsc && vite build` clean; `dist/node/async.js` emits as a real module.
- Ran the webcrypto path on Node → `demopublickey` → `1s4oyld5dc` (matches expected).

## Compatibility

Additive on the Node side (reject → compute); no change to browser, sync, or React Native paths. The only in-repo consumer (`upload-client` browser tool) uses the browser async path and is unaffected.
